### PR TITLE
Enable dark mode theme support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.env
+.DS_Store

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,11 +7,13 @@ import { RiskAnalysis } from './components/RiskAnalysis';
 import { QualityOfEarnings } from './components/QualityOfEarnings';
 import { Deliverables } from './components/Deliverables';
 import { AppProvider } from './context/AppContext';
+import { ThemeProvider, useTheme } from './context/ThemeContext';
 
 export type ViewType = 'dashboard' | 'import' | 'financials' | 'risk' | 'qoe' | 'deliverables';
 
-function App() {
+const AppLayout: React.FC = () => {
   const [currentView, setCurrentView] = useState<ViewType>('dashboard');
+  const { theme } = useTheme();
 
   const renderView = () => {
     switch (currentView) {
@@ -33,14 +35,24 @@ function App() {
   };
 
   return (
-    <AppProvider>
-      <div className="min-h-screen bg-gray-50">
+    <div className={theme === 'dark' ? 'dark' : ''}>
+      <div className="min-h-screen bg-gray-50 text-gray-900 transition-colors duration-300 dark:bg-slate-950 dark:text-slate-100">
         <Navigation currentView={currentView} onViewChange={setCurrentView} />
         <main className="pt-16">
           {renderView()}
         </main>
       </div>
-    </AppProvider>
+    </div>
+  );
+};
+
+function App() {
+  return (
+    <ThemeProvider>
+      <AppProvider>
+        <AppLayout />
+      </AppProvider>
+    </ThemeProvider>
   );
 }
 

--- a/src/components/AlertCard.tsx
+++ b/src/components/AlertCard.tsx
@@ -23,11 +23,11 @@ export const AlertCard: React.FC<AlertCardProps> = ({ type, title, message, prio
   const getStyles = () => {
     switch (type) {
       case 'error':
-        return 'bg-red-50 border-red-200 text-red-800';
+        return 'bg-red-50 border-red-200 text-red-800 dark:bg-red-500/10 dark:border-red-500/40 dark:text-red-100';
       case 'warning':
-        return 'bg-yellow-50 border-yellow-200 text-yellow-800';
+        return 'bg-yellow-50 border-yellow-200 text-yellow-800 dark:bg-yellow-500/10 dark:border-yellow-500/40 dark:text-yellow-100';
       case 'info':
-        return 'bg-blue-50 border-blue-200 text-blue-800';
+        return 'bg-blue-50 border-blue-200 text-blue-800 dark:bg-blue-500/10 dark:border-blue-500/40 dark:text-blue-100';
     }
   };
 

--- a/src/components/ChartCard.tsx
+++ b/src/components/ChartCard.tsx
@@ -1,61 +1,79 @@
 import React from 'react';
 
-interface ChartCardProps {
-  title: string;
-  type: 'line' | 'bar';
-  data: any[];
-}
+type LineChartData = {
+  month: string;
+  ebitda: number;
+  ca: number;
+};
 
-export const ChartCard: React.FC<ChartCardProps> = ({ title, type, data }) => {
-  const renderLineChart = () => {
-    const maxValue = Math.max(...data.flatMap(d => [d.ebitda, d.ca]));
-    
+type BarChartData = {
+  category: string;
+  value: number;
+  target: number;
+};
+
+type ChartCardProps =
+  | {
+      title: string;
+      type: 'line';
+      data: LineChartData[];
+    }
+  | {
+      title: string;
+      type: 'bar';
+      data: BarChartData[];
+    };
+
+export const ChartCard: React.FC<ChartCardProps> = (props) => {
+  const renderLineChart = (lineData: LineChartData[]) => {
+    const maxValue = Math.max(...lineData.flatMap(d => [d.ebitda, d.ca]));
+
     return (
       <div className="h-64 flex items-end space-x-2">
-        {data.map((item, index) => (
+        {lineData.map((item, index) => (
           <div key={index} className="flex-1 flex flex-col items-center space-y-1">
             <div className="flex flex-col items-center space-y-1 w-full">
-              <div 
+              <div
                 className="w-full bg-blue-500 rounded-t"
                 style={{ height: `${(item.ebitda / maxValue) * 180}px` }}
                 title={`EBITDA: ${item.ebitda}K€`}
               />
-              <div 
+              <div
                 className="w-full bg-green-500 rounded-t opacity-70"
                 style={{ height: `${(item.ca / maxValue) * 180}px` }}
                 title={`CA: ${item.ca}K€`}
               />
             </div>
-            <span className="text-xs text-gray-600">{item.month}</span>
+            <span className="text-xs text-gray-600 dark:text-slate-300">{item.month}</span>
           </div>
         ))}
       </div>
     );
   };
 
-  const renderBarChart = () => {
-    const maxValue = Math.max(...data.map(d => Math.abs(d.value)));
-    
+  const renderBarChart = (barData: BarChartData[]) => {
+    const maxValue = Math.max(...barData.map(d => Math.abs(d.value)));
+
     return (
       <div className="h-64 flex items-end space-x-4">
-        {data.map((item, index) => (
+        {barData.map((item, index) => (
           <div key={index} className="flex-1 flex flex-col items-center space-y-2">
             <div className="w-full relative">
-              <div 
+              <div
                 className={`w-full rounded ${item.value >= 0 ? 'bg-blue-500' : 'bg-red-500'}`}
-                style={{ 
+                style={{
                   height: `${(Math.abs(item.value) / maxValue) * 180}px`,
                   marginTop: item.value < 0 ? 'auto' : '0'
                 }}
                 title={`${item.category}: ${item.value}K€`}
               />
-              <div 
-                className="w-full border-2 border-dashed border-gray-400 absolute top-0"
+              <div
+                className="w-full border-2 border-dashed border-gray-400 absolute top-0 dark:border-slate-600"
                 style={{ height: `${(Math.abs(item.target) / maxValue) * 180}px` }}
                 title={`Target: ${item.target}K€`}
               />
             </div>
-            <span className="text-xs text-gray-600 text-center">{item.category}</span>
+            <span className="text-xs text-gray-600 text-center dark:text-slate-300">{item.category}</span>
           </div>
         ))}
       </div>
@@ -63,19 +81,19 @@ export const ChartCard: React.FC<ChartCardProps> = ({ title, type, data }) => {
   };
 
   return (
-    <div className="bg-white rounded-lg border border-gray-200 p-6">
-      <h3 className="text-lg font-semibold text-gray-900 mb-4">{title}</h3>
-      {type === 'line' ? renderLineChart() : renderBarChart()}
-      
-      {type === 'line' && (
+    <div className="bg-white rounded-lg border border-gray-200 p-6 dark:bg-slate-900 dark:border-slate-700">
+      <h3 className="text-lg font-semibold text-gray-900 mb-4 dark:text-slate-100">{props.title}</h3>
+      {props.type === 'line' ? renderLineChart(props.data) : renderBarChart(props.data)}
+
+      {props.type === 'line' && (
         <div className="flex justify-center mt-4 space-x-6">
           <div className="flex items-center space-x-2">
             <div className="w-3 h-3 bg-blue-500 rounded" />
-            <span className="text-sm text-gray-600">EBITDA</span>
+            <span className="text-sm text-gray-600 dark:text-slate-300">EBITDA</span>
           </div>
           <div className="flex items-center space-x-2">
             <div className="w-3 h-3 bg-green-500 rounded opacity-70" />
-            <span className="text-sm text-gray-600">Chiffre d'Affaires</span>
+            <span className="text-sm text-gray-600 dark:text-slate-300">Chiffre d'Affaires</span>
           </div>
         </div>
       )}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -80,14 +80,14 @@ export const Dashboard: React.FC = () => {
     <div className="max-w-7xl mx-auto px-4 py-6 space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Tableau de Bord</h1>
-          <p className="text-gray-600">Synthèse de la due diligence - Société ACME SAS</p>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-slate-100">Tableau de Bord</h1>
+          <p className="text-gray-600 dark:text-slate-300">Synthèse de la due diligence - Société ACME SAS</p>
         </div>
         <div className="flex space-x-3">
           <button className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors">
             Générer Rapport TS
           </button>
-          <button className="px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+          <button className="px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors dark:border-slate-600 dark:text-slate-200 dark:hover:bg-slate-800">
             Export Excel
           </button>
         </div>
@@ -130,8 +130,8 @@ export const Dashboard: React.FC = () => {
         {/* Right Column */}
         <div className="space-y-6">
           {/* Alerts */}
-          <div className="bg-white rounded-lg border border-gray-200 p-6">
-            <h3 className="text-lg font-semibold text-gray-900 mb-4 flex items-center">
+          <div className="bg-white rounded-lg border border-gray-200 p-6 dark:bg-slate-900 dark:border-slate-700">
+            <h3 className="text-lg font-semibold text-gray-900 mb-4 flex items-center dark:text-slate-100">
               <AlertCircle className="h-5 w-5 text-red-500 mr-2" />
               Alertes & Risques
             </h3>
@@ -143,8 +143,8 @@ export const Dashboard: React.FC = () => {
           </div>
 
           {/* Recent Activities */}
-          <div className="bg-white rounded-lg border border-gray-200 p-6">
-            <h3 className="text-lg font-semibold text-gray-900 mb-4 flex items-center">
+          <div className="bg-white rounded-lg border border-gray-200 p-6 dark:bg-slate-900 dark:border-slate-700">
+            <h3 className="text-lg font-semibold text-gray-900 mb-4 flex items-center dark:text-slate-100">
               <Calendar className="h-5 w-5 text-blue-500 mr-2" />
               Activité Récente
             </h3>
@@ -157,8 +157,8 @@ export const Dashboard: React.FC = () => {
                     <FileText className="h-4 w-4 text-yellow-500" />
                   )}
                   <div className="flex-1 min-w-0">
-                    <p className="text-sm text-gray-900">{activity.action}</p>
-                    <p className="text-xs text-gray-500">{activity.date}</p>
+                    <p className="text-sm text-gray-900 dark:text-slate-200">{activity.action}</p>
+                    <p className="text-xs text-gray-500 dark:text-slate-400">{activity.date}</p>
                   </div>
                 </div>
               ))}

--- a/src/components/Deliverables.tsx
+++ b/src/components/Deliverables.tsx
@@ -71,27 +71,6 @@ export const Deliverables: React.FC = () => {
     { id: 'fec_export', name: 'Annexes FEC' }
   ];
 
-  const customizationOptions = {
-    executive: {
-      showRisks: true,
-      includeQoE: true,
-      maskedVersion: false,
-      language: 'fr'
-    },
-    ts_report: {
-      includeAppendices: true,
-      detailedAnalysis: true,
-      maskedVersion: false,
-      confidentialityLevel: 'standard'
-    },
-    excel_master: {
-      protectedFormulas: true,
-      drillDownEnabled: true,
-      includeSourceData: true,
-      readOnlyMode: false
-    }
-  };
-
   const generateDeliverable = (id: string) => {
     alert(`Génération du livrable: ${deliverables.find(d => d.id === id)?.title}\nTraitement en cours...`);
   };
@@ -108,15 +87,15 @@ export const Deliverables: React.FC = () => {
     <div className="max-w-7xl mx-auto px-4 py-6 space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Livrables & Exports</h1>
-          <p className="text-gray-600">Génération automatique de rapports professionnels</p>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-slate-100">Livrables & Exports</h1>
+          <p className="text-gray-600 dark:text-slate-300">Génération automatique de rapports professionnels</p>
         </div>
         <div className="flex space-x-3">
-          <button className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors flex items-center space-x-2">
+          <button className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors flex items-center space-x-2 dark:bg-blue-500 dark:hover:bg-blue-400">
             <Download className="h-4 w-4" />
             <span>Tout Télécharger</span>
           </button>
-          <button className="px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors flex items-center space-x-2">
+          <button className="px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors flex items-center space-x-2 dark:border-slate-600 dark:text-slate-200 dark:hover:bg-slate-800">
             <Send className="h-4 w-4" />
             <span>Partager</span>
           </button>
@@ -124,17 +103,17 @@ export const Deliverables: React.FC = () => {
       </div>
 
       {/* Template Selection */}
-      <div className="bg-white rounded-lg border border-gray-200 p-6">
-        <h3 className="text-lg font-semibold text-gray-900 mb-4">Types de Livrables</h3>
+      <div className="bg-white rounded-lg border border-gray-200 p-6 dark:bg-slate-900 dark:border-slate-700">
+        <h3 className="text-lg font-semibold text-gray-900 mb-4 dark:text-slate-100">Types de Livrables</h3>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
           {templates.map((template) => (
             <button
               key={template.id}
               onClick={() => setSelectedTemplate(template.id)}
-              className={`p-4 border-2 rounded-lg text-left transition-colors ${
+              className={`p-4 border-2 rounded-lg text-left transition-colors text-gray-700 dark:text-slate-200 ${
                 selectedTemplate === template.id
-                  ? 'border-blue-500 bg-blue-50 text-blue-700'
-                  : 'border-gray-200 hover:border-gray-300'
+                  ? 'border-blue-500 bg-blue-50 text-blue-700 dark:border-blue-400 dark:bg-blue-500/20 dark:text-blue-100'
+                  : 'border-gray-200 hover:border-gray-300 dark:border-slate-700 dark:hover:border-slate-500'
               }`}
             >
               <div className="flex items-center space-x-2 mb-2">
@@ -145,7 +124,7 @@ export const Deliverables: React.FC = () => {
                 )}
                 <span className="font-medium">{template.name}</span>
               </div>
-              <p className="text-sm text-gray-600">
+              <p className="text-sm text-gray-600 dark:text-slate-300">
                 {deliverables.find(d => d.id === template.id)?.description}
               </p>
             </button>
@@ -158,22 +137,22 @@ export const Deliverables: React.FC = () => {
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
           <div className="lg:col-span-2 space-y-6">
             {/* Template Preview */}
-            <div className="bg-white rounded-lg border border-gray-200 p-6">
+            <div className="bg-white rounded-lg border border-gray-200 p-6 dark:bg-slate-900 dark:border-slate-700">
               <div className="flex items-center justify-between mb-4">
-                <h3 className="text-lg font-semibold text-gray-900">
+                <h3 className="text-lg font-semibold text-gray-900 dark:text-slate-100">
                   {deliverables.find(d => d.id === selectedTemplate)?.title}
                 </h3>
                 <div className="flex space-x-2">
-                  <button 
+                  <button
                     onClick={() => previewDeliverable(selectedTemplate)}
-                    className="px-3 py-1 border border-gray-300 text-gray-700 rounded hover:bg-gray-50 transition-colors flex items-center space-x-1"
+                    className="px-3 py-1 border border-gray-300 text-gray-700 rounded hover:bg-gray-50 transition-colors flex items-center space-x-1 dark:border-slate-600 dark:text-slate-200 dark:hover:bg-slate-800"
                   >
                     <Eye className="h-3 w-3" />
                     <span>Aperçu</span>
                   </button>
-                  <button 
+                  <button
                     onClick={() => generateDeliverable(selectedTemplate)}
-                    className="px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors flex items-center space-x-1"
+                    className="px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors flex items-center space-x-1 dark:bg-blue-500 dark:hover:bg-blue-400"
                   >
                     <Download className="h-3 w-3" />
                     <span>Générer</span>
@@ -184,32 +163,32 @@ export const Deliverables: React.FC = () => {
               <div className="space-y-4">
                 <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
                   <div>
-                    <span className="text-gray-600">Type:</span>
-                    <p className="font-medium">{deliverables.find(d => d.id === selectedTemplate)?.type}</p>
+                    <span className="text-gray-600 dark:text-slate-300">Type:</span>
+                    <p className="font-medium text-gray-900 dark:text-slate-100">{deliverables.find(d => d.id === selectedTemplate)?.type}</p>
                   </div>
                   <div>
-                    <span className="text-gray-600">Pages:</span>
-                    <p className="font-medium">{deliverables.find(d => d.id === selectedTemplate)?.pages}</p>
+                    <span className="text-gray-600 dark:text-slate-300">Pages:</span>
+                    <p className="font-medium text-gray-900 dark:text-slate-100">{deliverables.find(d => d.id === selectedTemplate)?.pages}</p>
                   </div>
                   <div>
-                    <span className="text-gray-600">Statut:</span>
-                    <span className="inline-flex px-2 py-1 bg-green-100 text-green-800 rounded text-xs font-medium">
+                    <span className="text-gray-600 dark:text-slate-300">Statut:</span>
+                    <span className="inline-flex px-2 py-1 bg-green-100 text-green-800 rounded text-xs font-medium dark:bg-green-500/20 dark:text-green-200">
                       Prêt
                     </span>
                   </div>
                   <div>
-                    <span className="text-gray-600">Dernière MAJ:</span>
-                    <p className="font-medium text-xs">{deliverables.find(d => d.id === selectedTemplate)?.lastGenerated}</p>
+                    <span className="text-gray-600 dark:text-slate-300">Dernière MAJ:</span>
+                    <p className="font-medium text-xs text-gray-900 dark:text-slate-100">{deliverables.find(d => d.id === selectedTemplate)?.lastGenerated}</p>
                   </div>
                 </div>
 
                 <div>
-                  <h4 className="font-medium text-gray-900 mb-2">Sections incluses:</h4>
+                  <h4 className="font-medium text-gray-900 mb-2 dark:text-slate-100">Sections incluses:</h4>
                   <div className="grid grid-cols-2 gap-2">
                     {deliverables.find(d => d.id === selectedTemplate)?.sections.map((section, index) => (
                       <div key={index} className="flex items-center space-x-2">
                         <div className="w-2 h-2 bg-blue-500 rounded-full" />
-                        <span className="text-sm text-gray-700">{section}</span>
+                        <span className="text-sm text-gray-700 dark:text-slate-300">{section}</span>
                       </div>
                     ))}
                   </div>
@@ -218,13 +197,13 @@ export const Deliverables: React.FC = () => {
             </div>
 
             {/* Content Preview */}
-            <div className="bg-white rounded-lg border border-gray-200 p-6">
-              <h4 className="font-medium text-gray-900 mb-4">Aperçu du Contenu</h4>
-              
+            <div className="bg-white rounded-lg border border-gray-200 p-6 dark:bg-slate-900 dark:border-slate-700">
+              <h4 className="font-medium text-gray-900 mb-4 dark:text-slate-100">Aperçu du Contenu</h4>
+
               {selectedTemplate === 'executive' && (
-                <div className="space-y-4 text-sm">
-                  <div className="p-4 bg-gray-50 rounded">
-                    <h5 className="font-medium mb-2">ACME SAS - Executive Summary</h5>
+                <div className="space-y-4 text-sm text-gray-700 dark:text-slate-200">
+                  <div className="p-4 bg-gray-50 rounded dark:bg-slate-800/60">
+                    <h5 className="font-medium mb-2 text-gray-900 dark:text-slate-100">ACME SAS - Executive Summary</h5>
                     <div className="grid grid-cols-2 gap-4">
                       <div>• CA LTM: 18.45 M€ (+7.9%)</div>
                       <div>• EBITDA Normalisé: 2.34 M€ (+23.2%)</div>
@@ -236,20 +215,20 @@ export const Deliverables: React.FC = () => {
               )}
 
               {selectedTemplate === 'ts_report' && (
-                <div className="space-y-3 text-sm">
-                  <div className="flex justify-between border-b pb-2">
+                <div className="space-y-3 text-sm text-gray-700 dark:text-slate-200">
+                  <div className="flex justify-between border-b border-gray-200 pb-2 dark:border-slate-700">
                     <span>1. Executive Summary</span><span>Page 1-2</span>
                   </div>
-                  <div className="flex justify-between border-b pb-2">
+                  <div className="flex justify-between border-b border-gray-200 pb-2 dark:border-slate-700">
                     <span>2. États Financiers Retraités</span><span>Page 3-8</span>
                   </div>
-                  <div className="flex justify-between border-b pb-2">
+                  <div className="flex justify-between border-b border-gray-200 pb-2 dark:border-slate-700">
                     <span>3. Quality of Earnings</span><span>Page 9-12</span>
                   </div>
-                  <div className="flex justify-between border-b pb-2">
+                  <div className="flex justify-between border-b border-gray-200 pb-2 dark:border-slate-700">
                     <span>4. Analyse BFR & Net Debt</span><span>Page 13-15</span>
                   </div>
-                  <div className="flex justify-between border-b pb-2">
+                  <div className="flex justify-between border-b border-gray-200 pb-2 dark:border-slate-700">
                     <span>5. Risk Assessment</span><span>Page 16-17</span>
                   </div>
                   <div className="flex justify-between">
@@ -259,7 +238,7 @@ export const Deliverables: React.FC = () => {
               )}
 
               {selectedTemplate === 'excel_master' && (
-                <div className="space-y-3 text-sm">
+                <div className="space-y-3 text-sm text-gray-700 dark:text-slate-200">
                   <div className="grid grid-cols-2 gap-4">
                     <div>📊 Dashboard</div>
                     <div>📈 P&L Retraité</div>
@@ -270,7 +249,7 @@ export const Deliverables: React.FC = () => {
                     <div>📊 Ratios & KPIs</div>
                     <div>📋 Sources FEC</div>
                   </div>
-                  <p className="text-gray-600 mt-3">
+                  <p className="text-gray-600 mt-3 dark:text-slate-300">
                     Toutes les formules sont protégées. Drill-down disponible sur chaque chiffre.
                   </p>
                 </div>
@@ -280,23 +259,23 @@ export const Deliverables: React.FC = () => {
 
           {/* Customization Panel */}
           <div className="space-y-6">
-            <div className="bg-white rounded-lg border border-gray-200 p-6">
-              <h4 className="font-medium text-gray-900 mb-4">Options de Personnalisation</h4>
-              
+            <div className="bg-white rounded-lg border border-gray-200 p-6 dark:bg-slate-900 dark:border-slate-700">
+              <h4 className="font-medium text-gray-900 mb-4 dark:text-slate-100">Options de Personnalisation</h4>
+
               <div className="space-y-4">
                 {selectedTemplate === 'executive' && (
                   <>
                     <div className="flex items-center justify-between">
-                      <span className="text-sm text-gray-700">Inclure les risques</span>
-                      <input type="checkbox" defaultChecked className="rounded" />
+                      <span className="text-sm text-gray-700 dark:text-slate-300">Inclure les risques</span>
+                      <input type="checkbox" defaultChecked className="rounded border-gray-300 text-blue-600 focus:ring-blue-500 dark:border-slate-600 dark:bg-slate-900" />
                     </div>
                     <div className="flex items-center justify-between">
-                      <span className="text-sm text-gray-700">Détail QoE</span>
-                      <input type="checkbox" defaultChecked className="rounded" />
+                      <span className="text-sm text-gray-700 dark:text-slate-300">Détail QoE</span>
+                      <input type="checkbox" defaultChecked className="rounded border-gray-300 text-blue-600 focus:ring-blue-500 dark:border-slate-600 dark:bg-slate-900" />
                     </div>
                     <div className="flex items-center justify-between">
-                      <span className="text-sm text-gray-700">Version anonymisée</span>
-                      <input type="checkbox" className="rounded" />
+                      <span className="text-sm text-gray-700 dark:text-slate-300">Version anonymisée</span>
+                      <input type="checkbox" className="rounded border-gray-300 text-blue-600 focus:ring-blue-500 dark:border-slate-600 dark:bg-slate-900" />
                     </div>
                   </>
                 )}
@@ -304,16 +283,16 @@ export const Deliverables: React.FC = () => {
                 {selectedTemplate === 'ts_report' && (
                   <>
                     <div className="flex items-center justify-between">
-                      <span className="text-sm text-gray-700">Annexes détaillées</span>
-                      <input type="checkbox" defaultChecked className="rounded" />
+                      <span className="text-sm text-gray-700 dark:text-slate-300">Annexes détaillées</span>
+                      <input type="checkbox" defaultChecked className="rounded border-gray-300 text-blue-600 focus:ring-blue-500 dark:border-slate-600 dark:bg-slate-900" />
                     </div>
                     <div className="flex items-center justify-between">
-                      <span className="text-sm text-gray-700">Analyse sectorielle</span>
-                      <input type="checkbox" defaultChecked className="rounded" />
+                      <span className="text-sm text-gray-700 dark:text-slate-300">Analyse sectorielle</span>
+                      <input type="checkbox" defaultChecked className="rounded border-gray-300 text-blue-600 focus:ring-blue-500 dark:border-slate-600 dark:bg-slate-900" />
                     </div>
                     <div>
-                      <label className="block text-sm text-gray-700 mb-1">Niveau de confidentialité</label>
-                      <select className="w-full text-sm border rounded px-2 py-1">
+                      <label className="block text-sm text-gray-700 mb-1 dark:text-slate-300">Niveau de confidentialité</label>
+                      <select className="w-full text-sm border rounded px-2 py-1 bg-white dark:bg-slate-900 dark:border-slate-700 dark:text-slate-100">
                         <option>Standard</option>
                         <option>Confidentiel</option>
                         <option>Très confidentiel</option>
@@ -325,23 +304,23 @@ export const Deliverables: React.FC = () => {
                 {selectedTemplate === 'excel_master' && (
                   <>
                     <div className="flex items-center justify-between">
-                      <span className="text-sm text-gray-700">Formules protégées</span>
-                      <input type="checkbox" defaultChecked className="rounded" />
+                      <span className="text-sm text-gray-700 dark:text-slate-300">Formules protégées</span>
+                      <input type="checkbox" defaultChecked className="rounded border-gray-300 text-blue-600 focus:ring-blue-500 dark:border-slate-600 dark:bg-slate-900" />
                     </div>
                     <div className="flex items-center justify-between">
-                      <span className="text-sm text-gray-700">Drill-down activé</span>
-                      <input type="checkbox" defaultChecked className="rounded" />
+                      <span className="text-sm text-gray-700 dark:text-slate-300">Drill-down activé</span>
+                      <input type="checkbox" defaultChecked className="rounded border-gray-300 text-blue-600 focus:ring-blue-500 dark:border-slate-600 dark:bg-slate-900" />
                     </div>
                     <div className="flex items-center justify-between">
-                      <span className="text-sm text-gray-700">Données sources</span>
-                      <input type="checkbox" defaultChecked className="rounded" />
+                      <span className="text-sm text-gray-700 dark:text-slate-300">Données sources</span>
+                      <input type="checkbox" defaultChecked className="rounded border-gray-300 text-blue-600 focus:ring-blue-500 dark:border-slate-600 dark:bg-slate-900" />
                     </div>
                   </>
                 )}
 
                 <div>
-                  <label className="block text-sm text-gray-700 mb-1">Format de date</label>
-                  <select className="w-full text-sm border rounded px-2 py-1">
+                  <label className="block text-sm text-gray-700 mb-1 dark:text-slate-300">Format de date</label>
+                  <select className="w-full text-sm border rounded px-2 py-1 bg-white dark:bg-slate-900 dark:border-slate-700 dark:text-slate-100">
                     <option>DD/MM/YYYY</option>
                     <option>MM/DD/YYYY</option>
                     <option>YYYY-MM-DD</option>
@@ -351,12 +330,12 @@ export const Deliverables: React.FC = () => {
             </div>
 
             {/* Generation History */}
-            <div className="bg-white rounded-lg border border-gray-200 p-6">
-              <h4 className="font-medium text-gray-900 mb-4 flex items-center">
+            <div className="bg-white rounded-lg border border-gray-200 p-6 dark:bg-slate-900 dark:border-slate-700">
+              <h4 className="font-medium text-gray-900 mb-4 flex items-center dark:text-slate-100">
                 <Calendar className="h-4 w-4 mr-2" />
                 Historique
               </h4>
-              
+
               <div className="space-y-3">
                 {[
                   { date: '15/01 16:50', version: 'v1.3', action: 'Généré' },
@@ -364,33 +343,33 @@ export const Deliverables: React.FC = () => {
                   { date: '14/01 18:45', version: 'v1.1', action: 'Généré' },
                   { date: '14/01 16:20', version: 'v1.0', action: 'Créé' }
                 ].map((item, index) => (
-                  <div key={index} className="flex items-center justify-between text-sm">
+                  <div key={index} className="flex items-center justify-between text-sm text-gray-700 dark:text-slate-200">
                     <div>
-                      <span className="font-medium">{item.version}</span>
-                      <span className="text-gray-600 ml-2">{item.action}</span>
+                      <span className="font-medium text-gray-900 dark:text-slate-100">{item.version}</span>
+                      <span className="text-gray-600 ml-2 dark:text-slate-300">{item.action}</span>
                     </div>
-                    <span className="text-gray-500">{item.date}</span>
+                    <span className="text-gray-500 dark:text-slate-400">{item.date}</span>
                   </div>
                 ))}
               </div>
             </div>
 
             {/* Quick Actions */}
-            <div className="bg-white rounded-lg border border-gray-200 p-6">
-              <h4 className="font-medium text-gray-900 mb-4">Actions Rapides</h4>
-              
+            <div className="bg-white rounded-lg border border-gray-200 p-6 dark:bg-slate-900 dark:border-slate-700">
+              <h4 className="font-medium text-gray-900 mb-4 dark:text-slate-100">Actions Rapides</h4>
+
               <div className="space-y-2">
-                <button 
+                <button
                   onClick={() => shareDeliverable(selectedTemplate)}
-                  className="w-full px-3 py-2 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors flex items-center justify-center space-x-2"
+                  className="w-full px-3 py-2 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors flex items-center justify-center space-x-2 dark:bg-blue-500 dark:hover:bg-blue-400"
                 >
                   <Send className="h-3 w-3" />
                   <span>Partager par email</span>
                 </button>
-                <button className="w-full px-3 py-2 text-sm border border-gray-300 text-gray-700 rounded hover:bg-gray-50 transition-colors">
+                <button className="w-full px-3 py-2 text-sm border border-gray-300 text-gray-700 rounded hover:bg-gray-50 transition-colors dark:border-slate-600 dark:text-slate-200 dark:hover:bg-slate-800">
                   Programmer génération
                 </button>
-                <button className="w-full px-3 py-2 text-sm border border-gray-300 text-gray-700 rounded hover:bg-gray-50 transition-colors">
+                <button className="w-full px-3 py-2 text-sm border border-gray-300 text-gray-700 rounded hover:bg-gray-50 transition-colors dark:border-slate-600 dark:text-slate-200 dark:hover:bg-slate-800">
                   Créer template custom
                 </button>
               </div>

--- a/src/components/FileImport.tsx
+++ b/src/components/FileImport.tsx
@@ -1,13 +1,32 @@
 import React, { useState } from 'react';
 import { Upload, FileText, CheckCircle, AlertCircle, Download } from 'lucide-react';
 
+type ControlStatus = 'passed' | 'warning';
+
+interface FileControl {
+  name: string;
+  status: ControlStatus;
+  message: string;
+}
+
+type FileProcessingStatus = 'uploaded' | 'processed';
+
+interface ImportedFile {
+  name: string;
+  size: number;
+  type: string;
+  status: FileProcessingStatus;
+  controls: FileControl[];
+  warnings: string[];
+}
+
 export const FileImport: React.FC = () => {
-  const [files, setFiles] = useState<any[]>([]);
+  const [files, setFiles] = useState<ImportedFile[]>([]);
   const [isProcessing, setIsProcessing] = useState(false);
 
   const handleFileUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
     const uploadedFiles = Array.from(event.target.files || []);
-    const newFiles = uploadedFiles.map(file => ({
+    const newFiles = uploadedFiles.map<ImportedFile>(file => ({
       name: file.name,
       size: file.size,
       type: file.type,
@@ -15,7 +34,7 @@ export const FileImport: React.FC = () => {
       controls: [],
       warnings: []
     }));
-    setFiles([...files, ...newFiles]);
+    setFiles(prev => [...prev, ...newFiles]);
   };
 
   const processFiles = () => {
@@ -55,12 +74,12 @@ export const FileImport: React.FC = () => {
     <div className="max-w-6xl mx-auto px-4 py-6 space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Import & Contrôles FEC</h1>
-          <p className="text-gray-600">Importez vos fichiers comptables et configurez les paramètres</p>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-slate-100">Import & Contrôles FEC</h1>
+          <p className="text-gray-600 dark:text-slate-300">Importez vos fichiers comptables et configurez les paramètres</p>
         </div>
-        <button 
+        <button
           onClick={downloadTemplate}
-          className="px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors flex items-center space-x-2"
+          className="px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors flex items-center space-x-2 dark:border-slate-600 dark:text-slate-200 dark:hover:bg-slate-800"
         >
           <Download className="h-4 w-4" />
           <span>Template Mapping</span>
@@ -68,13 +87,13 @@ export const FileImport: React.FC = () => {
       </div>
 
       {/* Upload Zone */}
-      <div className="bg-white rounded-lg border-2 border-dashed border-gray-300 p-8">
+      <div className="bg-white rounded-lg border-2 border-dashed border-gray-300 p-8 dark:bg-slate-900 dark:border-slate-700">
         <div className="text-center">
-          <Upload className="h-12 w-12 text-gray-400 mx-auto mb-4" />
-          <h3 className="text-lg font-medium text-gray-900 mb-2">
+          <Upload className="h-12 w-12 text-gray-400 mx-auto mb-4 dark:text-slate-500" />
+          <h3 className="text-lg font-medium text-gray-900 mb-2 dark:text-slate-100">
             Glissez vos fichiers ici ou cliquez pour sélectionner
           </h3>
-          <p className="text-gray-600 mb-4">
+          <p className="text-gray-600 mb-4 dark:text-slate-300">
             FEC (obligatoire), Balances, Grands livres, Auxiliaires
           </p>
           <input
@@ -96,9 +115,9 @@ export const FileImport: React.FC = () => {
 
       {/* File List */}
       {files.length > 0 && (
-        <div className="bg-white rounded-lg border border-gray-200 p-6">
+        <div className="bg-white rounded-lg border border-gray-200 p-6 dark:bg-slate-900 dark:border-slate-700">
           <div className="flex items-center justify-between mb-4">
-            <h3 className="text-lg font-semibold text-gray-900">Fichiers importés</h3>
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-slate-100">Fichiers importés</h3>
             {!isProcessing && files.some(f => f.status === 'uploaded') && (
               <button
                 onClick={processFiles}
@@ -117,13 +136,13 @@ export const FileImport: React.FC = () => {
 
           <div className="space-y-4">
             {files.map((file, index) => (
-              <div key={index} className="border border-gray-200 rounded-lg p-4">
+              <div key={index} className="border border-gray-200 rounded-lg p-4 bg-white dark:border-slate-700 dark:bg-slate-900/60">
                 <div className="flex items-center justify-between mb-2">
                   <div className="flex items-center space-x-3">
-                    <FileText className="h-5 w-5 text-blue-600" />
+                    <FileText className="h-5 w-5 text-blue-600 dark:text-blue-400" />
                     <div>
-                      <h4 className="font-medium text-gray-900">{file.name}</h4>
-                      <p className="text-sm text-gray-600">
+                      <h4 className="font-medium text-gray-900 dark:text-slate-100">{file.name}</h4>
+                      <p className="text-sm text-gray-600 dark:text-slate-300">
                         {(file.size / 1024).toFixed(1)} KB
                       </p>
                     </div>
@@ -133,9 +152,9 @@ export const FileImport: React.FC = () => {
                       <CheckCircle className="h-5 w-5 text-green-600" />
                     )}
                     <span className={`px-2 py-1 rounded text-sm font-medium ${
-                      file.status === 'processed' 
-                        ? 'bg-green-100 text-green-800' 
-                        : 'bg-yellow-100 text-yellow-800'
+                      file.status === 'processed'
+                        ? 'bg-green-100 text-green-800 dark:bg-green-500/20 dark:text-green-200'
+                        : 'bg-yellow-100 text-yellow-800 dark:bg-yellow-500/20 dark:text-yellow-200'
                     }`}>
                       {file.status === 'processed' ? 'Traité' : 'En attente'}
                     </span>
@@ -144,9 +163,9 @@ export const FileImport: React.FC = () => {
 
                 {file.controls && file.controls.length > 0 && (
                   <div className="mt-4">
-                    <h5 className="font-medium text-gray-900 mb-2">Contrôles automatiques</h5>
+                    <h5 className="font-medium text-gray-900 mb-2 dark:text-slate-100">Contrôles automatiques</h5>
                     <div className="space-y-2">
-                      {file.controls.map((control: any, controlIndex: number) => (
+                      {file.controls.map((control, controlIndex) => (
                         <div key={controlIndex} className="flex items-center space-x-2">
                           {control.status === 'passed' ? (
                             <CheckCircle className="h-4 w-4 text-green-600" />
@@ -154,7 +173,7 @@ export const FileImport: React.FC = () => {
                             <AlertCircle className="h-4 w-4 text-yellow-600" />
                           )}
                           <span className="text-sm font-medium">{control.name}:</span>
-                          <span className="text-sm text-gray-600">{control.message}</span>
+                          <span className="text-sm text-gray-600 dark:text-slate-300">{control.message}</span>
                         </div>
                       ))}
                     </div>
@@ -162,14 +181,14 @@ export const FileImport: React.FC = () => {
                 )}
 
                 {file.warnings && file.warnings.length > 0 && (
-                  <div className="mt-4 p-3 bg-yellow-50 rounded-lg">
-                    <h5 className="font-medium text-yellow-800 mb-2 flex items-center">
+                  <div className="mt-4 p-3 bg-yellow-50 rounded-lg dark:bg-yellow-500/10">
+                    <h5 className="font-medium text-yellow-800 mb-2 flex items-center dark:text-yellow-200">
                       <AlertCircle className="h-4 w-4 mr-1" />
                       Alertes détectées
                     </h5>
                     <ul className="space-y-1">
                       {file.warnings.map((warning: string, warningIndex: number) => (
-                        <li key={warningIndex} className="text-sm text-yellow-700">
+                        <li key={warningIndex} className="text-sm text-yellow-700 dark:text-yellow-200">
                           • {warning}
                         </li>
                       ))}
@@ -184,25 +203,25 @@ export const FileImport: React.FC = () => {
 
       {/* Configuration Panel */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <div className="bg-white rounded-lg border border-gray-200 p-6">
-          <h3 className="text-lg font-semibold text-gray-900 mb-4">Paramètres de Mapping</h3>
+        <div className="bg-white rounded-lg border border-gray-200 p-6 dark:bg-slate-900 dark:border-slate-700">
+          <h3 className="text-lg font-semibold text-gray-900 mb-4 dark:text-slate-100">Paramètres de Mapping</h3>
           <div className="space-y-4">
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">
+              <label className="block text-sm font-medium text-gray-700 mb-2 dark:text-slate-300">
                 Période d'analyse (LTM)
               </label>
-              <select className="w-full border border-gray-300 rounded-md px-3 py-2">
+              <select className="w-full border border-gray-300 rounded-md px-3 py-2 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100">
                 <option>Décembre 2024 (12 mois)</option>
                 <option>Novembre 2024 (12 mois)</option>
                 <option>Octobre 2024 (12 mois)</option>
               </select>
             </div>
-            
+
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">
+              <label className="block text-sm font-medium text-gray-700 mb-2 dark:text-slate-300">
                 Secteur d'activité
               </label>
-              <select className="w-full border border-gray-300 rounded-md px-3 py-2">
+              <select className="w-full border border-gray-300 rounded-md px-3 py-2 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100">
                 <option>Services B2B</option>
                 <option>BTP</option>
                 <option>Restauration</option>
@@ -212,40 +231,40 @@ export const FileImport: React.FC = () => {
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">
+              <label className="block text-sm font-medium text-gray-700 mb-2 dark:text-slate-300">
                 Seuil d'anomalie (€)
               </label>
-              <input 
-                type="number" 
+              <input
+                type="number"
                 defaultValue={1000}
-                className="w-full border border-gray-300 rounded-md px-3 py-2"
+                className="w-full border border-gray-300 rounded-md px-3 py-2 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
                 placeholder="1000"
               />
             </div>
           </div>
         </div>
 
-        <div className="bg-white rounded-lg border border-gray-200 p-6">
-          <h3 className="text-lg font-semibold text-gray-900 mb-4">Mapping PCG Personnalisé</h3>
+        <div className="bg-white rounded-lg border border-gray-200 p-6 dark:bg-slate-900 dark:border-slate-700">
+          <h3 className="text-lg font-semibold text-gray-900 mb-4 dark:text-slate-100">Mapping PCG Personnalisé</h3>
           <div className="space-y-3">
-            <div className="flex items-center justify-between p-2 bg-gray-50 rounded">
-              <span className="text-sm">70* → Chiffre d'affaires</span>
-              <button className="text-blue-600 text-sm hover:underline">Modifier</button>
+            <div className="flex items-center justify-between p-2 bg-gray-50 rounded dark:bg-slate-800">
+              <span className="text-sm dark:text-slate-200">70* → Chiffre d'affaires</span>
+              <button className="text-blue-600 text-sm hover:underline dark:text-blue-400">Modifier</button>
             </div>
-            <div className="flex items-center justify-between p-2 bg-gray-50 rounded">
-              <span className="text-sm">60* → Achats consommés</span>
-              <button className="text-blue-600 text-sm hover:underline">Modifier</button>
+            <div className="flex items-center justify-between p-2 bg-gray-50 rounded dark:bg-slate-800">
+              <span className="text-sm dark:text-slate-200">60* → Achats consommés</span>
+              <button className="text-blue-600 text-sm hover:underline dark:text-blue-400">Modifier</button>
             </div>
-            <div className="flex items-center justify-between p-2 bg-gray-50 rounded">
-              <span className="text-sm">64* → Charges externes</span>
-              <button className="text-blue-600 text-sm hover:underline">Modifier</button>
+            <div className="flex items-center justify-between p-2 bg-gray-50 rounded dark:bg-slate-800">
+              <span className="text-sm dark:text-slate-200">64* → Charges externes</span>
+              <button className="text-blue-600 text-sm hover:underline dark:text-blue-400">Modifier</button>
             </div>
-            <div className="flex items-center justify-between p-2 bg-gray-50 rounded">
-              <span className="text-sm">63* → Impôts et taxes</span>
-              <button className="text-blue-600 text-sm hover:underline">Modifier</button>
+            <div className="flex items-center justify-between p-2 bg-gray-50 rounded dark:bg-slate-800">
+              <span className="text-sm dark:text-slate-200">63* → Impôts et taxes</span>
+              <button className="text-blue-600 text-sm hover:underline dark:text-blue-400">Modifier</button>
             </div>
           </div>
-          <button className="w-full mt-4 px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+          <button className="w-full mt-4 px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors dark:border-slate-600 dark:text-slate-200 dark:hover:bg-slate-800">
             + Ajouter règle de mapping
           </button>
         </div>

--- a/src/components/FinancialStatements.tsx
+++ b/src/components/FinancialStatements.tsx
@@ -75,15 +75,15 @@ export const FinancialStatements: React.FC = () => {
     <div className="max-w-7xl mx-auto px-4 py-6 space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">États Financiers Retraités</h1>
-          <p className="text-gray-600">États normalisés avec drill-down jusqu'aux écritures FEC</p>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-slate-100">États Financiers Retraités</h1>
+          <p className="text-gray-600 dark:text-slate-300">États normalisés avec drill-down jusqu'aux écritures FEC</p>
         </div>
         <div className="flex space-x-3">
           <button className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors flex items-center space-x-2">
             <Download className="h-4 w-4" />
             <span>Export Excel TS</span>
           </button>
-          <button className="px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors flex items-center space-x-2">
+          <button className="px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors flex items-center space-x-2 dark:border-slate-600 dark:text-slate-200 dark:hover:bg-slate-800">
             <Calculator className="h-4 w-4" />
             <span>Recalculer</span>
           </button>
@@ -91,8 +91,8 @@ export const FinancialStatements: React.FC = () => {
       </div>
 
       {/* Statement Tabs */}
-      <div className="bg-white rounded-lg border border-gray-200">
-        <div className="border-b border-gray-200">
+      <div className="bg-white rounded-lg border border-gray-200 dark:bg-slate-900 dark:border-slate-700">
+        <div className="border-b border-gray-200 dark:border-slate-700">
           <nav className="flex space-x-8 px-6">
             {[
               { id: 'pl', label: 'Compte de Résultat', icon: TrendingUp },
@@ -104,8 +104,8 @@ export const FinancialStatements: React.FC = () => {
                 onClick={() => setActiveStatement(tab.id as StatementType)}
                 className={`py-4 px-1 border-b-2 font-medium text-sm flex items-center space-x-2 transition-colors ${
                   activeStatement === tab.id
-                    ? 'border-blue-500 text-blue-600'
-                    : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                    ? 'border-blue-500 text-blue-600 dark:border-blue-400 dark:text-blue-300'
+                    : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300 dark:text-slate-300 dark:hover:text-slate-100 dark:hover:border-slate-600'
                 }`}
               >
                 <tab.icon className="h-4 w-4" />
@@ -118,13 +118,13 @@ export const FinancialStatements: React.FC = () => {
         {/* Statement Content */}
         <div className="p-6">
           <div className="flex items-center justify-between mb-6">
-            <h2 className="text-xl font-semibold text-gray-900">{getTitle()}</h2>
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-slate-100">{getTitle()}</h2>
             <div className="flex items-center space-x-4">
-              <div className="text-sm text-gray-600">
-                <span className="font-medium">Période:</span> Janvier 2024 - Décembre 2024
+              <div className="text-sm text-gray-600 dark:text-slate-300">
+                <span className="font-medium text-gray-900 dark:text-slate-100">Période:</span> Janvier 2024 - Décembre 2024
               </div>
-              <div className="text-sm text-gray-600">
-                <span className="font-medium">Devise:</span> EUR (000)
+              <div className="text-sm text-gray-600 dark:text-slate-300">
+                <span className="font-medium text-gray-900 dark:text-slate-100">Devise:</span> EUR (000)
               </div>
             </div>
           </div>
@@ -132,29 +132,29 @@ export const FinancialStatements: React.FC = () => {
           <div className="overflow-x-auto">
             <table className="w-full">
               <thead>
-                <tr className="border-b border-gray-200">
-                  <th className="text-left py-3 px-4 font-semibold text-gray-900">Rubrique</th>
-                  <th className="text-right py-3 px-4 font-semibold text-gray-900">2024 (LTM)</th>
-                  <th className="text-right py-3 px-4 font-semibold text-gray-900">2023</th>
-                  <th className="text-right py-3 px-4 font-semibold text-gray-900">Δ %</th>
-                  <th className="text-center py-3 px-4 font-semibold text-gray-900">Comptes PCG</th>
-                  <th className="text-center py-3 px-4 font-semibold text-gray-900">Actions</th>
+                <tr className="border-b border-gray-200 dark:border-slate-700">
+                  <th className="text-left py-3 px-4 font-semibold text-gray-900 dark:text-slate-100">Rubrique</th>
+                  <th className="text-right py-3 px-4 font-semibold text-gray-900 dark:text-slate-100">2024 (LTM)</th>
+                  <th className="text-right py-3 px-4 font-semibold text-gray-900 dark:text-slate-100">2023</th>
+                  <th className="text-right py-3 px-4 font-semibold text-gray-900 dark:text-slate-100">Δ %</th>
+                  <th className="text-center py-3 px-4 font-semibold text-gray-900 dark:text-slate-100">Comptes PCG</th>
+                  <th className="text-center py-3 px-4 font-semibold text-gray-900 dark:text-slate-100">Actions</th>
                 </tr>
               </thead>
               <tbody>
                 {getCurrentData().map((row, index) => (
-                  <tr 
-                    key={index} 
-                    className={`border-b border-gray-100 hover:bg-gray-50 transition-colors ${
-                      row.isCalculated ? 'bg-blue-50 font-semibold' : ''
+                  <tr
+                    key={index}
+                    className={`border-b border-gray-100 hover:bg-gray-50 transition-colors dark:border-slate-800 dark:hover:bg-slate-800 ${
+                      row.isCalculated ? 'bg-blue-50 font-semibold dark:bg-blue-500/10' : ''
                     }`}
                   >
-                    <td className="py-3 px-4 text-gray-900">{row.label}</td>
+                    <td className="py-3 px-4 text-gray-900 dark:text-slate-200">{row.label}</td>
                     <td className="py-3 px-4 text-right font-mono">
                       {row.current > 0 ? '' : ''}
                       {Math.abs(row.current).toLocaleString('fr-FR')}
                     </td>
-                    <td className="py-3 px-4 text-right font-mono text-gray-600">
+                    <td className="py-3 px-4 text-right font-mono text-gray-600 dark:text-slate-300">
                       {row.previous > 0 ? '' : ''}
                       {Math.abs(row.previous).toLocaleString('fr-FR')}
                     </td>
@@ -165,9 +165,9 @@ export const FinancialStatements: React.FC = () => {
                     </td>
                     <td className="py-3 px-4 text-center">
                       <span className={`px-2 py-1 rounded text-xs font-medium ${
-                        row.isCalculated 
-                          ? 'bg-blue-100 text-blue-800' 
-                          : 'bg-gray-100 text-gray-700'
+                        row.isCalculated
+                          ? 'bg-blue-100 text-blue-800 dark:bg-blue-500/20 dark:text-blue-200'
+                          : 'bg-gray-100 text-gray-700 dark:bg-slate-800 dark:text-slate-200'
                       }`}>
                         {row.accounts}
                       </span>
@@ -175,7 +175,7 @@ export const FinancialStatements: React.FC = () => {
                     <td className="py-3 px-4 text-center">
                       <button
                         onClick={() => drillDown(row.accounts)}
-                        className="text-blue-600 hover:text-blue-800 transition-colors"
+                        className="text-blue-600 hover:text-blue-800 transition-colors dark:text-blue-300 dark:hover:text-blue-200"
                         title="Drill-down vers écritures FEC"
                       >
                         <Eye className="h-4 w-4" />
@@ -189,8 +189,8 @@ export const FinancialStatements: React.FC = () => {
 
           {/* Additional Analytics */}
           <div className="mt-8 grid grid-cols-1 md:grid-cols-3 gap-6">
-            <div className="bg-gray-50 rounded-lg p-4">
-              <h4 className="font-semibold text-gray-900 mb-2">Ratios Clés</h4>
+            <div className="bg-gray-50 rounded-lg p-4 dark:bg-slate-900/60 dark:text-slate-200">
+              <h4 className="font-semibold text-gray-900 mb-2 dark:text-slate-100">Ratios Clés</h4>
               <div className="space-y-2 text-sm">
                 <div className="flex justify-between">
                   <span>Marge EBITDA</span>
@@ -207,8 +207,8 @@ export const FinancialStatements: React.FC = () => {
               </div>
             </div>
 
-            <div className="bg-gray-50 rounded-lg p-4">
-              <h4 className="font-semibold text-gray-900 mb-2">Évolution vs N-1</h4>
+            <div className="bg-gray-50 rounded-lg p-4 dark:bg-slate-900/60 dark:text-slate-200">
+              <h4 className="font-semibold text-gray-900 mb-2 dark:text-slate-100">Évolution vs N-1</h4>
               <div className="space-y-2 text-sm">
                 <div className="flex justify-between">
                   <span>Croissance CA</span>
@@ -225,8 +225,8 @@ export const FinancialStatements: React.FC = () => {
               </div>
             </div>
 
-            <div className="bg-gray-50 rounded-lg p-4">
-              <h4 className="font-semibold text-gray-900 mb-2">Contrôles</h4>
+            <div className="bg-gray-50 rounded-lg p-4 dark:bg-slate-900/60 dark:text-slate-200">
+              <h4 className="font-semibold text-gray-900 mb-2 dark:text-slate-100">Contrôles</h4>
               <div className="space-y-2 text-sm">
                 <div className="flex justify-between items-center">
                   <span>Équilibre</span>

--- a/src/components/KpiCard.tsx
+++ b/src/components/KpiCard.tsx
@@ -18,21 +18,21 @@ export const KpiCard: React.FC<KpiCardProps> = ({
   icon: Icon, 
   detail 
 }) => {
-  const trendColor = trend === 'up' ? 'text-green-600' : 'text-red-600';
-  const bgColor = trend === 'up' ? 'bg-green-50' : 'bg-red-50';
+  const trendColor = trend === 'up' ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400';
+  const bgColor = trend === 'up' ? 'bg-green-50 dark:bg-green-500/10' : 'bg-red-50 dark:bg-red-500/10';
 
   return (
-    <div className="bg-white rounded-lg border border-gray-200 p-6 hover:shadow-md transition-shadow cursor-pointer">
+    <div className="bg-white rounded-lg border border-gray-200 p-6 hover:shadow-md transition-shadow cursor-pointer dark:bg-slate-900 dark:border-slate-700">
       <div className="flex items-center justify-between mb-4">
-        <Icon className="h-8 w-8 text-blue-600" />
+        <Icon className="h-8 w-8 text-blue-600 dark:text-blue-400" />
         <span className={`px-2 py-1 rounded text-sm font-medium ${bgColor} ${trendColor}`}>
           {change}
         </span>
       </div>
-      
-      <h3 className="text-lg font-semibold text-gray-900 mb-2">{title}</h3>
-      <p className="text-3xl font-bold text-gray-900 mb-1">{value}</p>
-      <p className="text-sm text-gray-600">{detail}</p>
+
+      <h3 className="text-lg font-semibold text-gray-900 mb-2 dark:text-slate-100">{title}</h3>
+      <p className="text-3xl font-bold text-gray-900 mb-1 dark:text-slate-100">{value}</p>
+      <p className="text-sm text-gray-600 dark:text-slate-300">{detail}</p>
     </div>
   );
 };

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,14 +1,17 @@
 import React from 'react';
 import { ViewType } from '../App';
-import { 
-  LayoutDashboard, 
-  Upload, 
-  FileText, 
-  AlertTriangle, 
-  TrendingUp, 
+import {
+  LayoutDashboard,
+  Upload,
+  FileText,
+  AlertTriangle,
+  TrendingUp,
   Download,
-  Zap
+  Zap,
+  Moon,
+  Sun
 } from 'lucide-react';
+import { useTheme } from '../context/ThemeContext';
 
 interface NavigationProps {
   currentView: ViewType;
@@ -16,6 +19,9 @@ interface NavigationProps {
 }
 
 export const Navigation: React.FC<NavigationProps> = ({ currentView, onViewChange }) => {
+  const { theme, toggleTheme } = useTheme();
+  const isDarkMode = theme === 'dark';
+
   const navItems = [
     { id: 'dashboard' as ViewType, label: 'Tableau de Bord', icon: LayoutDashboard },
     { id: 'import' as ViewType, label: 'Import FEC', icon: Upload },
@@ -26,28 +32,30 @@ export const Navigation: React.FC<NavigationProps> = ({ currentView, onViewChang
   ];
 
   return (
-    <nav className="fixed top-0 left-0 right-0 bg-white border-b border-gray-200 z-50">
+    <nav className="fixed top-0 left-0 right-0 bg-white border-b border-gray-200 z-50 dark:bg-slate-900 dark:border-slate-800">
       <div className="max-w-7xl mx-auto px-4">
         <div className="flex items-center justify-between h-16">
           <div className="flex items-center space-x-3">
             <Zap className="h-8 w-8 text-blue-600" />
-            <h1 className="text-xl font-bold text-gray-900">Pégase</h1>
-            <span className="text-sm text-gray-500">Due Diligence Platform</span>
+            <h1 className="text-xl font-bold text-gray-900 dark:text-white">Pégase</h1>
+            <span className="text-sm text-gray-500 dark:text-slate-300">Due Diligence Platform</span>
           </div>
-          
-          <div className="flex space-x-1">
+
+          <div className="flex items-center space-x-1">
             {navItems.map((item) => {
               const Icon = item.icon;
               const isActive = currentView === item.id;
-              
+
               return (
                 <button
                   key={item.id}
+                  type="button"
                   onClick={() => onViewChange(item.id)}
+                  aria-current={isActive ? 'page' : undefined}
                   className={`px-3 py-2 rounded-md text-sm font-medium transition-colors duration-200 flex items-center space-x-2 ${
                     isActive
-                      ? 'bg-blue-100 text-blue-700'
-                      : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
+                      ? 'bg-blue-100 text-blue-700 dark:bg-blue-500/20 dark:text-blue-100'
+                      : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100 dark:text-slate-300 dark:hover:text-white dark:hover:bg-slate-800'
                   }`}
                 >
                   <Icon className="h-4 w-4" />
@@ -55,6 +63,22 @@ export const Navigation: React.FC<NavigationProps> = ({ currentView, onViewChang
                 </button>
               );
             })}
+
+            <div className="ml-2 pl-3 border-l border-gray-200 dark:border-slate-700">
+              <button
+                type="button"
+                onClick={toggleTheme}
+                aria-pressed={isDarkMode}
+                className="flex items-center space-x-2 px-3 py-2 rounded-md text-sm font-medium transition-colors duration-200 text-gray-600 hover:text-gray-900 hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:text-slate-300 dark:hover:text-white dark:hover:bg-slate-800"
+              >
+                {isDarkMode ? (
+                  <Sun className="h-4 w-4" aria-hidden="true" />
+                ) : (
+                  <Moon className="h-4 w-4" aria-hidden="true" />
+                )}
+                <span>{isDarkMode ? 'Mode sombre' : 'Mode clair'}</span>
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/QualityOfEarnings.tsx
+++ b/src/components/QualityOfEarnings.tsx
@@ -91,16 +91,16 @@ export const QualityOfEarnings: React.FC = () => {
   };
 
   const getProbabilityColor = (prob: number) => {
-    if (prob >= 90) return 'text-green-600 bg-green-100';
-    if (prob >= 75) return 'text-yellow-600 bg-yellow-100';
-    return 'text-red-600 bg-red-100';
+    if (prob >= 90) return 'text-green-600 bg-green-100 dark:text-green-200 dark:bg-green-500/20';
+    if (prob >= 75) return 'text-yellow-600 bg-yellow-100 dark:text-yellow-200 dark:bg-yellow-500/20';
+    return 'text-red-600 bg-red-100 dark:text-red-200 dark:bg-red-500/20';
   };
 
   const getStatusIcon = (status: string) => {
     switch (status) {
       case 'accepted': return <CheckCircle className="h-4 w-4 text-green-600" />;
       case 'rejected': return <X className="h-4 w-4 text-red-600" />;
-      default: return <div className="h-4 w-4 border-2 border-gray-300 rounded" />;
+      default: return <div className="h-4 w-4 border-2 border-gray-300 rounded dark:border-slate-500" />;
     }
   };
 
@@ -112,15 +112,15 @@ export const QualityOfEarnings: React.FC = () => {
     <div className="max-w-7xl mx-auto px-4 py-6 space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Quality of Earnings</h1>
-          <p className="text-gray-600">Normalisation assistée de l'EBITDA</p>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-slate-100">Quality of Earnings</h1>
+          <p className="text-gray-600 dark:text-slate-300">Normalisation assistée de l'EBITDA</p>
         </div>
         <div className="flex space-x-3">
           <button className="px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors flex items-center space-x-2">
             <Download className="h-4 w-4" />
             <span>Export QoE</span>
           </button>
-          <button className="px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+          <button className="px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors dark:border-slate-600 dark:text-slate-200 dark:hover:bg-slate-800">
             Recalculer
           </button>
         </div>
@@ -128,70 +128,70 @@ export const QualityOfEarnings: React.FC = () => {
 
       {/* EBITDA Summary */}
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-        <div className="bg-white rounded-lg border border-gray-200 p-4">
-          <h3 className="text-sm font-medium text-gray-600 mb-2">EBITDA Reporté</h3>
-          <p className="text-2xl font-bold text-gray-900">2 230 K€</p>
-          <p className="text-sm text-gray-500">LTM Décembre 2024</p>
+        <div className="bg-white rounded-lg border border-gray-200 p-4 dark:bg-slate-900 dark:border-slate-700">
+          <h3 className="text-sm font-medium text-gray-600 mb-2 dark:text-slate-300">EBITDA Reporté</h3>
+          <p className="text-2xl font-bold text-gray-900 dark:text-slate-100">2 230 K€</p>
+          <p className="text-sm text-gray-500 dark:text-slate-300">LTM Décembre 2024</p>
         </div>
-        <div className="bg-white rounded-lg border border-gray-200 p-4">
-          <h3 className="text-sm font-medium text-gray-600 mb-2">Ajustements Validés</h3>
+        <div className="bg-white rounded-lg border border-gray-200 p-4 dark:bg-slate-900 dark:border-slate-700">
+          <h3 className="text-sm font-medium text-gray-600 mb-2 dark:text-slate-300">Ajustements Validés</h3>
           <p className={`text-2xl font-bold ${getTotalAdjustments() >= 0 ? 'text-green-600' : 'text-red-600'}`}>
             {getTotalAdjustments() > 0 ? '+' : ''}{getTotalAdjustments()} K€
           </p>
-          <p className="text-sm text-gray-500">{adjustments.filter(a => a.status === 'accepted').length} ajustements</p>
+          <p className="text-sm text-gray-500 dark:text-slate-300">{adjustments.filter(a => a.status === 'accepted').length} ajustements</p>
         </div>
-        <div className="bg-blue-50 rounded-lg border border-blue-200 p-4">
-          <h3 className="text-sm font-medium text-blue-600 mb-2">EBITDA Normalisé</h3>
-          <p className="text-2xl font-bold text-blue-900">{getEbitdaNormalized().toLocaleString('fr-FR')} K€</p>
-          <p className="text-sm text-blue-600">Après ajustements QoE</p>
+        <div className="bg-blue-50 rounded-lg border border-blue-200 p-4 dark:bg-blue-500/10 dark:border-blue-500/40">
+          <h3 className="text-sm font-medium text-blue-600 mb-2 dark:text-blue-200">EBITDA Normalisé</h3>
+          <p className="text-2xl font-bold text-blue-900 dark:text-blue-200">{getEbitdaNormalized().toLocaleString('fr-FR')} K€</p>
+          <p className="text-sm text-blue-600 dark:text-blue-200">Après ajustements QoE</p>
         </div>
-        <div className="bg-white rounded-lg border border-gray-200 p-4">
-          <h3 className="text-sm font-medium text-gray-600 mb-2">Multiple Impact</h3>
-          <p className="text-2xl font-bold text-gray-900">+{(getTotalAdjustments() * 8).toLocaleString('fr-FR')} K€</p>
-          <p className="text-sm text-gray-500">@ 8x EBITDA</p>
+        <div className="bg-white rounded-lg border border-gray-200 p-4 dark:bg-slate-900 dark:border-slate-700">
+          <h3 className="text-sm font-medium text-gray-600 mb-2 dark:text-slate-300">Multiple Impact</h3>
+          <p className="text-2xl font-bold text-gray-900 dark:text-slate-100">+{(getTotalAdjustments() * 8).toLocaleString('fr-FR')} K€</p>
+          <p className="text-sm text-gray-500 dark:text-slate-300">@ 8x EBITDA</p>
         </div>
       </div>
 
       {/* Adjustments Table */}
-      <div className="bg-white rounded-lg border border-gray-200 overflow-hidden">
-        <div className="px-6 py-4 border-b border-gray-200">
-          <h3 className="text-lg font-semibold text-gray-900">Ajustements Détectés</h3>
-          <p className="text-sm text-gray-600">Validation assistée par IA avec scoring de probabilité</p>
+      <div className="bg-white rounded-lg border border-gray-200 overflow-hidden dark:bg-slate-900 dark:border-slate-700">
+        <div className="px-6 py-4 border-b border-gray-200 dark:border-slate-700">
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-slate-100">Ajustements Détectés</h3>
+          <p className="text-sm text-gray-600 dark:text-slate-300">Validation assistée par IA avec scoring de probabilité</p>
         </div>
 
         <div className="overflow-x-auto">
           <table className="w-full">
-            <thead className="bg-gray-50">
+            <thead className="bg-gray-50 dark:bg-slate-900">
               <tr>
-                <th className="text-left py-3 px-4 font-semibold text-gray-900">Statut</th>
-                <th className="text-left py-3 px-4 font-semibold text-gray-900">Catégorie</th>
-                <th className="text-left py-3 px-4 font-semibold text-gray-900">Description</th>
-                <th className="text-right py-3 px-4 font-semibold text-gray-900">Montant (K€)</th>
-                <th className="text-center py-3 px-4 font-semibold text-gray-900">Probabilité</th>
-                <th className="text-center py-3 px-4 font-semibold text-gray-900">Compte</th>
-                <th className="text-center py-3 px-4 font-semibold text-gray-900">Actions</th>
+                <th className="text-left py-3 px-4 font-semibold text-gray-900 dark:text-slate-100">Statut</th>
+                <th className="text-left py-3 px-4 font-semibold text-gray-900 dark:text-slate-100">Catégorie</th>
+                <th className="text-left py-3 px-4 font-semibold text-gray-900 dark:text-slate-100">Description</th>
+                <th className="text-right py-3 px-4 font-semibold text-gray-900 dark:text-slate-100">Montant (K€)</th>
+                <th className="text-center py-3 px-4 font-semibold text-gray-900 dark:text-slate-100">Probabilité</th>
+                <th className="text-center py-3 px-4 font-semibold text-gray-900 dark:text-slate-100">Compte</th>
+                <th className="text-center py-3 px-4 font-semibold text-gray-900 dark:text-slate-100">Actions</th>
               </tr>
             </thead>
             <tbody>
               {adjustments.map((adjustment) => (
-                <tr key={adjustment.id} className="border-b border-gray-100 hover:bg-gray-50">
+                <tr key={adjustment.id} className="border-b border-gray-100 hover:bg-gray-50 dark:border-slate-800 dark:hover:bg-slate-800">
                   <td className="py-3 px-4">
                     {getStatusIcon(adjustment.status)}
                   </td>
                   <td className="py-3 px-4">
                     <span className={`px-2 py-1 rounded text-xs font-medium ${
-                      adjustment.category === 'Non-récurrent' ? 'bg-red-100 text-red-800' :
-                      adjustment.category === 'Owner benefit' ? 'bg-purple-100 text-purple-800' :
-                      adjustment.category === 'Reclassement' ? 'bg-blue-100 text-blue-800' :
-                      'bg-green-100 text-green-800'
+                      adjustment.category === 'Non-récurrent' ? 'bg-red-100 text-red-800 dark:bg-red-500/20 dark:text-red-200' :
+                      adjustment.category === 'Owner benefit' ? 'bg-purple-100 text-purple-800 dark:bg-purple-500/20 dark:text-purple-200' :
+                      adjustment.category === 'Reclassement' ? 'bg-blue-100 text-blue-800 dark:bg-blue-500/20 dark:text-blue-200' :
+                      'bg-green-100 text-green-800 dark:bg-green-500/20 dark:text-green-200'
                     }`}>
                       {adjustment.category}
                     </span>
                   </td>
                   <td className="py-3 px-4">
                     <div>
-                      <p className="font-medium text-gray-900">{adjustment.description}</p>
-                      <p className="text-sm text-gray-600">{adjustment.justification}</p>
+                      <p className="font-medium text-gray-900 dark:text-slate-100">{adjustment.description}</p>
+                      <p className="text-sm text-gray-600 dark:text-slate-300">{adjustment.justification}</p>
                     </div>
                   </td>
                   <td className={`py-3 px-4 text-right font-mono font-medium ${
@@ -205,7 +205,7 @@ export const QualityOfEarnings: React.FC = () => {
                     </span>
                   </td>
                   <td className="py-3 px-4 text-center">
-                    <span className="px-2 py-1 bg-gray-100 text-gray-800 rounded text-xs font-mono">
+                    <span className="px-2 py-1 bg-gray-100 text-gray-800 rounded text-xs font-mono dark:bg-slate-800 dark:text-slate-200">
                       {adjustment.account}
                     </span>
                   </td>
@@ -247,8 +247,8 @@ export const QualityOfEarnings: React.FC = () => {
 
       {/* Analysis Summary */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <div className="bg-white rounded-lg border border-gray-200 p-6">
-          <h3 className="text-lg font-semibold text-gray-900 mb-4 flex items-center">
+        <div className="bg-white rounded-lg border border-gray-200 p-6 dark:bg-slate-900 dark:border-slate-700">
+          <h3 className="text-lg font-semibold text-gray-900 mb-4 flex items-center dark:text-slate-100">
             <TrendingUp className="h-5 w-5 text-blue-600 mr-2" />
             Synthèse des Ajustements
           </h3>
@@ -259,10 +259,10 @@ export const QualityOfEarnings: React.FC = () => {
               { category: 'Reclassements', count: 1, amount: -28 },
               { category: 'Provisions', count: 1, amount: 12 }
             ].map((item, index) => (
-              <div key={index} className="flex items-center justify-between py-2 border-b border-gray-100 last:border-0">
-                <span className="text-sm text-gray-700">{item.category}</span>
+              <div key={index} className="flex items-center justify-between py-2 border-b border-gray-100 last:border-0 dark:border-slate-700">
+                <span className="text-sm text-gray-700 dark:text-slate-300">{item.category}</span>
                 <div className="text-right">
-                  <span className="text-sm font-medium text-gray-900">{item.count} ajustement(s)</span>
+                  <span className="text-sm font-medium text-gray-900 dark:text-slate-100">{item.count} ajustement(s)</span>
                   <p className={`text-sm font-medium ${item.amount > 0 ? 'text-green-600' : 'text-red-600'}`}>
                     {item.amount > 0 ? '+' : ''}{item.amount} K€
                   </p>
@@ -272,21 +272,21 @@ export const QualityOfEarnings: React.FC = () => {
           </div>
         </div>
 
-        <div className="bg-white rounded-lg border border-gray-200 p-6">
-          <h3 className="text-lg font-semibold text-gray-900 mb-4">Recommandations</h3>
+        <div className="bg-white rounded-lg border border-gray-200 p-6 dark:bg-slate-900 dark:border-slate-700">
+          <h3 className="text-lg font-semibold text-gray-900 mb-4 dark:text-slate-100">Recommandations</h3>
           <div className="space-y-4">
-            <div className="p-3 bg-green-50 rounded-lg">
-              <h4 className="font-medium text-green-900 mb-1">Points Forts</h4>
-              <ul className="text-sm text-green-800 space-y-1">
+            <div className="p-3 bg-green-50 rounded-lg dark:bg-green-500/10">
+              <h4 className="font-medium text-green-900 mb-1 dark:text-green-200">Points Forts</h4>
+              <ul className="text-sm text-green-800 space-y-1 dark:text-green-200">
                 <li>• EBITDA sous-jacent solide (+28K€ d'ajustements)</li>
                 <li>• Peu d'éléments non-récurrents significatifs</li>
                 <li>• Provisions prudentielles</li>
               </ul>
             </div>
-            
-            <div className="p-3 bg-yellow-50 rounded-lg">
-              <h4 className="font-medium text-yellow-900 mb-1">Points d'Attention</h4>
-              <ul className="text-sm text-yellow-800 space-y-1">
+
+            <div className="p-3 bg-yellow-50 rounded-lg dark:bg-yellow-500/10">
+              <h4 className="font-medium text-yellow-900 mb-1 dark:text-yellow-200">Points d'Attention</h4>
+              <ul className="text-sm text-yellow-800 space-y-1 dark:text-yellow-200">
                 <li>• Surveiller les owner benefits récurrents</li>
                 <li>• Documenter les ajustements pour l'audit</li>
                 <li>• Validation comptable recommandée</li>

--- a/src/components/RiskAnalysis.tsx
+++ b/src/components/RiskAnalysis.tsx
@@ -94,10 +94,10 @@ export const RiskAnalysis: React.FC = () => {
 
   const getRiskColor = (type: string) => {
     switch (type) {
-      case 'critical': return 'bg-red-50 border-red-200';
-      case 'high': return 'bg-orange-50 border-orange-200';
-      case 'warning': return 'bg-yellow-50 border-yellow-200';
-      case 'info': return 'bg-blue-50 border-blue-200';
+      case 'critical': return 'bg-red-50 border-red-200 dark:bg-red-500/10 dark:border-red-500/40';
+      case 'high': return 'bg-orange-50 border-orange-200 dark:bg-orange-500/10 dark:border-orange-500/40';
+      case 'warning': return 'bg-yellow-50 border-yellow-200 dark:bg-yellow-500/10 dark:border-yellow-500/40';
+      case 'info': return 'bg-blue-50 border-blue-200 dark:bg-blue-500/10 dark:border-blue-500/40';
     }
   };
 
@@ -120,15 +120,15 @@ export const RiskAnalysis: React.FC = () => {
     <div className="max-w-7xl mx-auto px-4 py-6 space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Analyse des Risques</h1>
-          <p className="text-gray-600">Détection automatique d'anomalies et points d'attention</p>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-slate-100">Analyse des Risques</h1>
+          <p className="text-gray-600 dark:text-slate-300">Détection automatique d'anomalies et points d'attention</p>
         </div>
         <div className="flex space-x-3">
           <button className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors flex items-center space-x-2">
             <Download className="h-4 w-4" />
             <span>Rapport Risques</span>
           </button>
-          <button className="px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors flex items-center space-x-2">
+          <button className="px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors flex items-center space-x-2 dark:border-slate-600 dark:text-slate-200 dark:hover:bg-slate-800">
             <Filter className="h-4 w-4" />
             <span>Seuils</span>
           </button>
@@ -143,11 +143,11 @@ export const RiskAnalysis: React.FC = () => {
           { label: 'Alertes', count: 2, color: 'bg-yellow-500', textColor: 'text-yellow-600' },
           { label: 'Informations', count: 1, color: 'bg-blue-500', textColor: 'text-blue-600' }
         ].map((summary, index) => (
-          <div key={index} className="bg-white rounded-lg border border-gray-200 p-4">
+          <div key={index} className="bg-white rounded-lg border border-gray-200 p-4 dark:bg-slate-900 dark:border-slate-700">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm text-gray-600">{summary.label}</p>
-                <p className="text-2xl font-bold text-gray-900">{summary.count}</p>
+                <p className="text-sm text-gray-600 dark:text-slate-300">{summary.label}</p>
+                <p className="text-2xl font-bold text-gray-900 dark:text-slate-100">{summary.count}</p>
               </div>
               <div className={`w-3 h-3 rounded-full ${summary.color}`} />
             </div>
@@ -156,14 +156,14 @@ export const RiskAnalysis: React.FC = () => {
       </div>
 
       {/* Category Filters */}
-      <div className="bg-white rounded-lg border border-gray-200 p-4">
+      <div className="bg-white rounded-lg border border-gray-200 p-4 dark:bg-slate-900 dark:border-slate-700">
         <div className="flex flex-wrap gap-2">
           <button
             onClick={() => setSelectedCategory('all')}
             className={`px-3 py-2 rounded-md text-sm font-medium transition-colors flex items-center space-x-2 ${
               selectedCategory === 'all'
-                ? 'bg-blue-100 text-blue-700'
-                : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
+                ? 'bg-blue-100 text-blue-700 dark:bg-blue-500/20 dark:text-blue-200'
+                : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100 dark:text-slate-300 dark:hover:text-slate-100 dark:hover:bg-slate-800'
             }`}
           >
             <span>Tous les risques</span>
@@ -180,8 +180,8 @@ export const RiskAnalysis: React.FC = () => {
               onClick={() => setSelectedCategory(category.id)}
               className={`px-3 py-2 rounded-md text-sm font-medium transition-colors flex items-center space-x-2 ${
                 selectedCategory === category.id
-                  ? 'bg-blue-100 text-blue-700'
-                  : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
+                  ? 'bg-blue-100 text-blue-700 dark:bg-blue-500/20 dark:text-blue-200'
+                  : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100 dark:text-slate-300 dark:hover:text-slate-100 dark:hover:bg-slate-800'
               }`}
             >
               {getCategoryIcon(category.id)}
@@ -202,40 +202,40 @@ export const RiskAnalysis: React.FC = () => {
               <div className="flex items-start space-x-3">
                 {getRiskIcon(risk.type)}
                 <div>
-                  <h3 className="text-lg font-semibold text-gray-900">{risk.title}</h3>
-                  <p className="text-gray-700 mt-1">{risk.description}</p>
+                  <h3 className="text-lg font-semibold text-gray-900 dark:text-slate-100">{risk.title}</h3>
+                  <p className="text-gray-700 mt-1 dark:text-slate-300">{risk.description}</p>
                 </div>
               </div>
               <div className="text-right">
-                <p className="text-sm text-gray-600">Impact financier</p>
-                <p className="text-xl font-bold text-gray-900">{risk.amount}</p>
+                <p className="text-sm text-gray-600 dark:text-slate-300">Impact financier</p>
+                <p className="text-xl font-bold text-gray-900 dark:text-slate-100">{risk.amount}</p>
               </div>
             </div>
 
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
               <div>
-                <h4 className="font-medium text-gray-900 mb-2">Détails de l'analyse</h4>
-                <p className="text-sm text-gray-700">{risk.details}</p>
+                <h4 className="font-medium text-gray-900 mb-2 dark:text-slate-100">Détails de l'analyse</h4>
+                <p className="text-sm text-gray-700 dark:text-slate-300">{risk.details}</p>
               </div>
               <div>
-                <h4 className="font-medium text-gray-900 mb-2">Recommandation</h4>
-                <p className="text-sm text-gray-700">{risk.recommendation}</p>
+                <h4 className="font-medium text-gray-900 mb-2 dark:text-slate-100">Recommandation</h4>
+                <p className="text-sm text-gray-700 dark:text-slate-300">{risk.recommendation}</p>
               </div>
             </div>
 
-            <div className="flex items-center justify-between pt-4 border-t border-gray-200">
+            <div className="flex items-center justify-between pt-4 border-t border-gray-200 dark:border-slate-700">
               <div className="flex items-center space-x-4">
-                <span className="text-sm text-gray-600">
-                  <span className="font-medium">Comptes:</span> {risk.accounts}
+                <span className="text-sm text-gray-600 dark:text-slate-300">
+                  <span className="font-medium text-gray-900 dark:text-slate-100">Comptes:</span> {risk.accounts}
                 </span>
-                <span className="text-sm text-gray-600">
-                  <span className="font-medium">Impact:</span> {risk.impact}
+                <span className="text-sm text-gray-600 dark:text-slate-300">
+                  <span className="font-medium text-gray-900 dark:text-slate-100">Impact:</span> {risk.impact}
                 </span>
               </div>
               <div className="flex space-x-2">
                 <button
                   onClick={() => drillDown(risk.accounts, risk.id)}
-                  className="px-3 py-1 bg-white text-gray-700 border border-gray-300 rounded hover:bg-gray-50 transition-colors text-sm flex items-center space-x-1"
+                  className="px-3 py-1 bg-white text-gray-700 border border-gray-300 rounded hover:bg-gray-50 transition-colors text-sm flex items-center space-x-1 dark:bg-slate-900 dark:text-slate-200 dark:border-slate-600 dark:hover:bg-slate-800"
                 >
                   <Eye className="h-3 w-3" />
                   <span>Voir détail</span>
@@ -251,8 +251,8 @@ export const RiskAnalysis: React.FC = () => {
 
       {/* Risk Analytics */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <div className="bg-white rounded-lg border border-gray-200 p-6">
-          <h3 className="text-lg font-semibold text-gray-900 mb-4">Distribution des Risques</h3>
+        <div className="bg-white rounded-lg border border-gray-200 p-6 dark:bg-slate-900 dark:border-slate-700">
+          <h3 className="text-lg font-semibold text-gray-900 mb-4 dark:text-slate-100">Distribution des Risques</h3>
           <div className="space-y-3">
             {[
               { category: 'Revenus & CA', count: 1, percentage: 17 },
@@ -262,43 +262,43 @@ export const RiskAnalysis: React.FC = () => {
               { category: 'Stocks & actifs', count: 1, percentage: 17 }
             ].map((item, index) => (
               <div key={index} className="flex items-center justify-between">
-                <span className="text-sm text-gray-700">{item.category}</span>
+                <span className="text-sm text-gray-700 dark:text-slate-300">{item.category}</span>
                 <div className="flex items-center space-x-3">
-                  <div className="w-24 bg-gray-200 rounded-full h-2">
-                    <div 
-                      className="bg-blue-600 h-2 rounded-full" 
+                  <div className="w-24 bg-gray-200 rounded-full h-2 dark:bg-slate-700">
+                    <div
+                      className="bg-blue-600 h-2 rounded-full"
                       style={{ width: `${item.percentage}%` }}
                     />
                   </div>
-                  <span className="text-sm font-medium text-gray-900">{item.count}</span>
+                  <span className="text-sm font-medium text-gray-900 dark:text-slate-100">{item.count}</span>
                 </div>
               </div>
             ))}
           </div>
         </div>
 
-        <div className="bg-white rounded-lg border border-gray-200 p-6">
-          <h3 className="text-lg font-semibold text-gray-900 mb-4">Actions Recommandées</h3>
+        <div className="bg-white rounded-lg border border-gray-200 p-6 dark:bg-slate-900 dark:border-slate-700">
+          <h3 className="text-lg font-semibold text-gray-900 mb-4 dark:text-slate-100">Actions Recommandées</h3>
           <div className="space-y-3">
             <div className="flex items-start space-x-3">
               <div className="w-2 h-2 bg-red-500 rounded-full mt-2" />
               <div>
-                <p className="text-sm font-medium text-gray-900">Priorité 1</p>
-                <p className="text-sm text-gray-600">Analyser le cut-off des revenus de décembre</p>
+                <p className="text-sm font-medium text-gray-900 dark:text-slate-100">Priorité 1</p>
+                <p className="text-sm text-gray-600 dark:text-slate-300">Analyser le cut-off des revenus de décembre</p>
               </div>
             </div>
             <div className="flex items-start space-x-3">
               <div className="w-2 h-2 bg-orange-500 rounded-full mt-2" />
               <div>
-                <p className="text-sm font-medium text-gray-900">Priorité 2</p>
-                <p className="text-sm text-gray-600">Évaluer le risque de concentration client</p>
+                <p className="text-sm font-medium text-gray-900 dark:text-slate-100">Priorité 2</p>
+                <p className="text-sm text-gray-600 dark:text-slate-300">Évaluer le risque de concentration client</p>
               </div>
             </div>
             <div className="flex items-start space-x-3">
               <div className="w-2 h-2 bg-yellow-500 rounded-full mt-2" />
               <div>
-                <p className="text-sm font-medium text-gray-900">Priorité 3</p>
-                <p className="text-sm text-gray-600">Justifier les écritures d'OD de fin d'exercice</p>
+                <p className="text-sm font-medium text-gray-900 dark:text-slate-100">Priorité 3</p>
+                <p className="text-sm text-gray-600 dark:text-slate-300">Justifier les écritures d'OD de fin d'exercice</p>
               </div>
             </div>
           </div>

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -1,0 +1,97 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode
+} from 'react';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextValue {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+  toggleTheme: () => void;
+}
+
+const STORAGE_KEY = 'pegase:theme-preference';
+
+const getInitialTheme = (): Theme => {
+  if (typeof window === 'undefined') {
+    return 'light';
+  }
+
+  const storedTheme = window.localStorage.getItem(STORAGE_KEY) as Theme | null;
+  if (storedTheme === 'light' || storedTheme === 'dark') {
+    return storedTheme;
+  }
+
+  const prefersDark = window.matchMedia?.('(prefers-color-scheme: dark)').matches;
+  return prefersDark ? 'dark' : 'light';
+};
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+export const ThemeProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [theme, setThemeState] = useState<Theme>(getInitialTheme);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    window.localStorage.setItem(STORAGE_KEY, theme);
+  }, [theme]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    const handleChange = (event: MediaQueryListEvent) => {
+      setThemeState(() => {
+        const storedTheme = window.localStorage.getItem(STORAGE_KEY) as Theme | null;
+        if (storedTheme === 'light' || storedTheme === 'dark') {
+          return storedTheme;
+        }
+
+        return event.matches ? 'dark' : 'light';
+      });
+    };
+
+    mediaQuery.addEventListener('change', handleChange);
+    return () => mediaQuery.removeEventListener('change', handleChange);
+  }, []);
+
+  const setTheme = useCallback((nextTheme: Theme) => {
+    setThemeState(nextTheme);
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    setThemeState(prev => (prev === 'dark' ? 'light' : 'dark'));
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      theme,
+      setTheme,
+      toggleTheme,
+    }),
+    [theme, setTheme, toggleTheme]
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+};
+
+export const useTheme = (): ThemeContextValue => {
+  const context = useContext(ThemeContext);
+
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+
+  return context;
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {},


### PR DESCRIPTION
## Summary
- enable Tailwind's class-based dark mode and add a theme context with persisted preference
- wrap the app with the theme provider, expose a navigation toggle, and finish dark styling for deliverables and other cards
- tighten TypeScript typing for chart and import utilities and ignore build artefacts in version control

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbe721aae08331b6cb4606946b6681