### PR TITLE
Add marketing home view and improve typing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.DS_Store

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Navigation } from './components/Navigation';
+import { Home } from './components/Home';
 import { Dashboard } from './components/Dashboard';
 import { FileImport } from './components/FileImport';
 import { FinancialStatements } from './components/FinancialStatements';
@@ -8,13 +9,22 @@ import { QualityOfEarnings } from './components/QualityOfEarnings';
 import { Deliverables } from './components/Deliverables';
 import { AppProvider } from './context/AppContext';
 
-export type ViewType = 'dashboard' | 'import' | 'financials' | 'risk' | 'qoe' | 'deliverables';
+export type ViewType =
+  | 'home'
+  | 'dashboard'
+  | 'import'
+  | 'financials'
+  | 'risk'
+  | 'qoe'
+  | 'deliverables';
 
 function App() {
-  const [currentView, setCurrentView] = useState<ViewType>('dashboard');
+  const [currentView, setCurrentView] = useState<ViewType>('home');
 
   const renderView = () => {
     switch (currentView) {
+      case 'home':
+        return <Home onNavigate={setCurrentView} />;
       case 'dashboard':
         return <Dashboard />;
       case 'import':
@@ -28,7 +38,7 @@ function App() {
       case 'deliverables':
         return <Deliverables />;
       default:
-        return <Dashboard />;
+        return <Home onNavigate={setCurrentView} />;
     }
   };
 

--- a/src/components/ChartCard.tsx
+++ b/src/components/ChartCard.tsx
@@ -1,28 +1,51 @@
 import React from 'react';
 
-interface ChartCardProps {
-  title: string;
-  type: 'line' | 'bar';
-  data: any[];
-}
+type LineChartDataPoint = {
+  month: string;
+  ebitda: number;
+  ca: number;
+};
+
+type BarChartDataPoint = {
+  category: string;
+  value: number;
+  target: number;
+};
+
+type ChartCardProps =
+  | {
+      title: string;
+      type: 'line';
+      data: LineChartDataPoint[];
+    }
+  | {
+      title: string;
+      type: 'bar';
+      data: BarChartDataPoint[];
+    };
+
+const getSafeMaxValue = (values: number[]) => {
+  const maxValue = Math.max(...values);
+  return maxValue === 0 ? 1 : maxValue;
+};
 
 export const ChartCard: React.FC<ChartCardProps> = ({ title, type, data }) => {
-  const renderLineChart = () => {
-    const maxValue = Math.max(...data.flatMap(d => [d.ebitda, d.ca]));
-    
+  const renderLineChart = (lineData: LineChartDataPoint[]) => {
+    const safeMaxValue = getSafeMaxValue(lineData.flatMap(item => [item.ebitda, item.ca]));
+
     return (
       <div className="h-64 flex items-end space-x-2">
-        {data.map((item, index) => (
+        {lineData.map((item, index) => (
           <div key={index} className="flex-1 flex flex-col items-center space-y-1">
             <div className="flex flex-col items-center space-y-1 w-full">
-              <div 
+              <div
                 className="w-full bg-blue-500 rounded-t"
-                style={{ height: `${(item.ebitda / maxValue) * 180}px` }}
+                style={{ height: `${(item.ebitda / safeMaxValue) * 180}px` }}
                 title={`EBITDA: ${item.ebitda}K€`}
               />
-              <div 
+              <div
                 className="w-full bg-green-500 rounded-t opacity-70"
-                style={{ height: `${(item.ca / maxValue) * 180}px` }}
+                style={{ height: `${(item.ca / safeMaxValue) * 180}px` }}
                 title={`CA: ${item.ca}K€`}
               />
             </div>
@@ -33,25 +56,25 @@ export const ChartCard: React.FC<ChartCardProps> = ({ title, type, data }) => {
     );
   };
 
-  const renderBarChart = () => {
-    const maxValue = Math.max(...data.map(d => Math.abs(d.value)));
-    
+  const renderBarChart = (barData: BarChartDataPoint[]) => {
+    const safeMaxValue = getSafeMaxValue(barData.map(datum => Math.abs(datum.value)));
+
     return (
       <div className="h-64 flex items-end space-x-4">
-        {data.map((item, index) => (
+        {barData.map((item, index) => (
           <div key={index} className="flex-1 flex flex-col items-center space-y-2">
             <div className="w-full relative">
-              <div 
+              <div
                 className={`w-full rounded ${item.value >= 0 ? 'bg-blue-500' : 'bg-red-500'}`}
-                style={{ 
-                  height: `${(Math.abs(item.value) / maxValue) * 180}px`,
+                style={{
+                  height: `${(Math.abs(item.value) / safeMaxValue) * 180}px`,
                   marginTop: item.value < 0 ? 'auto' : '0'
                 }}
                 title={`${item.category}: ${item.value}K€`}
               />
-              <div 
+              <div
                 className="w-full border-2 border-dashed border-gray-400 absolute top-0"
-                style={{ height: `${(Math.abs(item.target) / maxValue) * 180}px` }}
+                style={{ height: `${(Math.abs(item.target) / safeMaxValue) * 180}px` }}
                 title={`Target: ${item.target}K€`}
               />
             </div>
@@ -65,8 +88,8 @@ export const ChartCard: React.FC<ChartCardProps> = ({ title, type, data }) => {
   return (
     <div className="bg-white rounded-lg border border-gray-200 p-6">
       <h3 className="text-lg font-semibold text-gray-900 mb-4">{title}</h3>
-      {type === 'line' ? renderLineChart() : renderBarChart()}
-      
+      {type === 'line' ? renderLineChart(data) : renderBarChart(data)}
+
       {type === 'line' && (
         <div className="flex justify-center mt-4 space-x-6">
           <div className="flex items-center space-x-2">

--- a/src/components/Deliverables.tsx
+++ b/src/components/Deliverables.tsx
@@ -71,27 +71,6 @@ export const Deliverables: React.FC = () => {
     { id: 'fec_export', name: 'Annexes FEC' }
   ];
 
-  const customizationOptions = {
-    executive: {
-      showRisks: true,
-      includeQoE: true,
-      maskedVersion: false,
-      language: 'fr'
-    },
-    ts_report: {
-      includeAppendices: true,
-      detailedAnalysis: true,
-      maskedVersion: false,
-      confidentialityLevel: 'standard'
-    },
-    excel_master: {
-      protectedFormulas: true,
-      drillDownEnabled: true,
-      includeSourceData: true,
-      readOnlyMode: false
-    }
-  };
-
   const generateDeliverable = (id: string) => {
     alert(`Génération du livrable: ${deliverables.find(d => d.id === id)?.title}\nTraitement en cours...`);
   };

--- a/src/components/FileImport.tsx
+++ b/src/components/FileImport.tsx
@@ -1,8 +1,27 @@
 import React, { useState } from 'react';
 import { Upload, FileText, CheckCircle, AlertCircle, Download } from 'lucide-react';
 
+type ControlStatus = 'passed' | 'warning';
+
+interface FileControl {
+  name: string;
+  status: ControlStatus;
+  message: string;
+}
+
+type FileProcessingStatus = 'uploaded' | 'processed';
+
+interface ImportedFile {
+  name: string;
+  size: number;
+  type: string;
+  status: FileProcessingStatus;
+  controls: FileControl[];
+  warnings: string[];
+}
+
 export const FileImport: React.FC = () => {
-  const [files, setFiles] = useState<any[]>([]);
+  const [files, setFiles] = useState<ImportedFile[]>([]);
   const [isProcessing, setIsProcessing] = useState(false);
 
   const handleFileUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -12,7 +31,7 @@ export const FileImport: React.FC = () => {
       size: file.size,
       type: file.type,
       status: 'uploaded',
-      controls: [],
+      controls: [] as FileControl[],
       warnings: []
     }));
     setFiles([...files, ...newFiles]);
@@ -20,10 +39,10 @@ export const FileImport: React.FC = () => {
 
   const processFiles = () => {
     setIsProcessing(true);
-    
+
     // Simulate processing
     setTimeout(() => {
-      const processedFiles = files.map(file => ({
+      const processedFiles = files.map<ImportedFile>(file => ({
         ...file,
         status: 'processed',
         controls: [
@@ -146,7 +165,7 @@ export const FileImport: React.FC = () => {
                   <div className="mt-4">
                     <h5 className="font-medium text-gray-900 mb-2">Contrôles automatiques</h5>
                     <div className="space-y-2">
-                      {file.controls.map((control: any, controlIndex: number) => (
+                {file.controls.map((control, controlIndex) => (
                         <div key={controlIndex} className="flex items-center space-x-2">
                           {control.status === 'passed' ? (
                             <CheckCircle className="h-4 w-4 text-green-600" />

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -1,0 +1,224 @@
+import React from 'react';
+import type { ViewType } from '../App';
+import {
+  AlertTriangle,
+  ArrowRight,
+  Download,
+  FileSpreadsheet,
+  FileText,
+  LayoutDashboard,
+  ShieldCheck,
+  TrendingUp,
+  Upload,
+  Workflow,
+  Zap
+} from 'lucide-react';
+
+interface HomeProps {
+  onNavigate: (view: ViewType) => void;
+}
+
+export const Home: React.FC<HomeProps> = ({ onNavigate }) => {
+  const highlights = [
+    {
+      icon: FileSpreadsheet,
+      title: 'Contrôles FEC automatisés',
+      description: 'Mapping PCG, contrôles d\'intégrité et alertes en quelques minutes.'
+    },
+    {
+      icon: ShieldCheck,
+      title: 'Fiable & traçable',
+      description: 'Chaque analyse est horodatée, commentée et prête à être auditée.'
+    },
+    {
+      icon: Workflow,
+      title: 'Narratif augmenté',
+      description: 'Co-pilotage génératif pour accélérer la rédaction de vos livrables.'
+    }
+  ];
+
+  const modules: Array<{
+    view: ViewType;
+    title: string;
+    description: string;
+    icon: React.ComponentType<{ className?: string }>;
+    action: string;
+  }> = [
+    {
+      view: 'dashboard',
+      title: 'Cockpit de pilotage',
+      description: 'Visualisez instantanément la performance, les tendances et les alertes critiques.',
+      icon: LayoutDashboard,
+      action: 'Aller au tableau de bord'
+    },
+    {
+      view: 'import',
+      title: 'Import & contrôles',
+      description: 'Déposez votre FEC, laissez Pégase exécuter les contrôles et prioriser les anomalies.',
+      icon: Upload,
+      action: 'Lancer un import FEC'
+    },
+    {
+      view: 'financials',
+      title: 'États financiers intelligents',
+      description: 'Analysez bilans et comptes de résultats avec nos visualisations dynamiques.',
+      icon: FileText,
+      action: 'Explorer les états financiers'
+    },
+    {
+      view: 'risk',
+      title: 'Analyse des risques',
+      description: 'Identifiez les signaux faibles, suivez leur criticité et affectez-les à vos équipes.',
+      icon: AlertTriangle,
+      action: 'Analyser les risques'
+    },
+    {
+      view: 'qoe',
+      title: 'Quality of Earnings augmenté',
+      description: 'Structurez un narratif solide et documenté, propulsé par notre moteur génératif.',
+      icon: TrendingUp,
+      action: 'Structurer le QoE'
+    },
+    {
+      view: 'deliverables',
+      title: 'Livrables instantanés',
+      description: 'Exportez en un clic vos rapports TS et packs investisseurs prêts à partager.',
+      icon: Download,
+      action: 'Préparer les livrables'
+    }
+  ];
+
+  return (
+    <div className="bg-white">
+      <section className="relative overflow-hidden">
+        <div
+          className="absolute inset-0 bg-gradient-to-br from-blue-50 via-white to-indigo-50"
+          aria-hidden="true"
+        />
+        <div className="relative max-w-6xl mx-auto px-4 py-20 lg:py-28">
+          <div className="grid gap-16 lg:grid-cols-2 lg:items-center">
+            <div>
+              <span className="inline-flex items-center space-x-2 rounded-full bg-blue-100 px-3 py-1 text-sm font-medium text-blue-700">
+                <Zap className="h-4 w-4" />
+                <span>Due diligence augmentée</span>
+              </span>
+              <h1 className="mt-6 text-4xl font-extrabold tracking-tight text-gray-900 sm:text-5xl">
+                Accélérez vos analyses Transaction Services avec Pégase
+              </h1>
+              <p className="mt-6 text-lg leading-relaxed text-gray-700">
+                Pégase allie automatisation financière, intelligence des risques et narration générative pour
+                offrir aux équipes TS une vision 360° de la cible. Libérez du temps sur l\'analyse, sécurisez vos
+                conclusions et livrez plus vite.
+              </p>
+              <div className="mt-10 flex flex-col gap-3 sm:flex-row">
+                <button
+                  type="button"
+                  onClick={() => onNavigate('dashboard')}
+                  className="inline-flex items-center justify-center rounded-lg bg-blue-600 px-6 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-blue-700"
+                >
+                  Découvrir le cockpit
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onNavigate('import')}
+                  className="inline-flex items-center justify-center rounded-lg border border-blue-200 px-6 py-3 text-base font-semibold text-blue-700 transition hover:border-blue-300 hover:bg-blue-50"
+                >
+                  Importer un FEC maintenant
+                </button>
+              </div>
+              <div className="mt-8 grid gap-4 sm:grid-cols-3">
+                {highlights.map((highlight) => {
+                  const Icon = highlight.icon;
+                  return (
+                    <div key={highlight.title} className="rounded-xl border border-blue-100 bg-white/70 p-4 shadow-sm">
+                      <Icon className="h-6 w-6 text-blue-600" />
+                      <p className="mt-3 text-sm font-semibold text-gray-900">{highlight.title}</p>
+                      <p className="mt-2 text-sm text-gray-600">{highlight.description}</p>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+            <div className="relative">
+              <div className="absolute -right-10 -top-10 h-40 w-40 rounded-full bg-blue-200/50 blur-3xl" aria-hidden="true" />
+              <div className="relative rounded-3xl border border-blue-100 bg-white/80 p-8 shadow-xl backdrop-blur">
+                <h2 className="text-lg font-semibold text-gray-900">Ce que disent nos équipes pilotes</h2>
+                <p className="mt-4 text-sm leading-relaxed text-gray-600">
+                  « Nous passons de la collecte à l\'analyse en quelques heures. Pégase hiérarchise les points de
+                  vigilance et suggère les recommandations clés pour la note d\'investissement. »
+                </p>
+                <div className="mt-6 rounded-2xl bg-blue-50 p-6">
+                  <p className="text-sm font-semibold uppercase tracking-widest text-blue-600">Workflow type</p>
+                  <ol className="mt-4 space-y-3 text-sm text-blue-900">
+                    <li className="flex items-start space-x-3">
+                      <span className="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-white text-sm font-semibold text-blue-600">
+                        1
+                      </span>
+                      <p>Importez le FEC et laissez Pégase lancer plus de 180 contrôles automatiques.</p>
+                    </li>
+                    <li className="flex items-start space-x-3">
+                      <span className="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-white text-sm font-semibold text-blue-600">
+                        2
+                      </span>
+                      <p>Explorez les KPIs, tendances et alertes prioritaires dans le cockpit.</p>
+                    </li>
+                    <li className="flex items-start space-x-3">
+                      <span className="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-white text-sm font-semibold text-blue-600">
+                        3
+                      </span>
+                      <p>Générez votre narratif QoE et vos livrables en quelques clics.</p>
+                    </li>
+                  </ol>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => onNavigate('qoe')}
+                  className="mt-6 inline-flex items-center text-sm font-semibold text-blue-600 hover:text-blue-700"
+                >
+                  Voir comment Pégase construit un QoE <ArrowRight className="ml-2 h-4 w-4" />
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="max-w-6xl mx-auto px-4 pb-24">
+        <div className="max-w-2xl">
+          <h2 className="text-3xl font-semibold text-gray-900">Choisissez votre prochain module</h2>
+          <p className="mt-4 text-base text-gray-600">
+            Pégase vous accompagne à chaque étape de la due diligence. Passez à l'action dès maintenant en
+            accédant directement au module qui correspond à votre besoin.
+          </p>
+        </div>
+        <div className="mt-12 grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {modules.map((module) => {
+            const Icon = module.icon;
+            return (
+              <div
+                key={module.view}
+                className="flex h-full flex-col rounded-2xl border border-gray-200 bg-white p-6 shadow-sm transition hover:border-blue-300 hover:shadow-md"
+              >
+                <div className="flex items-center space-x-3">
+                  <span className="inline-flex h-12 w-12 items-center justify-center rounded-xl bg-blue-50 text-blue-600">
+                    <Icon className="h-6 w-6" />
+                  </span>
+                  <h3 className="text-lg font-semibold text-gray-900">{module.title}</h3>
+                </div>
+                <p className="mt-4 flex-1 text-sm text-gray-600">{module.description}</p>
+                <button
+                  type="button"
+                  onClick={() => onNavigate(module.view)}
+                  className="mt-6 inline-flex items-center text-sm font-semibold text-blue-600 hover:text-blue-700"
+                >
+                  {module.action}
+                  <ArrowRight className="ml-2 h-4 w-4" />
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+    </div>
+  );
+};

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { ViewType } from '../App';
-import { 
-  LayoutDashboard, 
-  Upload, 
-  FileText, 
-  AlertTriangle, 
-  TrendingUp, 
+import {
+  Home as HomeIcon,
+  LayoutDashboard,
+  Upload,
+  FileText,
+  AlertTriangle,
+  TrendingUp,
   Download,
   Zap
 } from 'lucide-react';
@@ -17,10 +18,11 @@ interface NavigationProps {
 
 export const Navigation: React.FC<NavigationProps> = ({ currentView, onViewChange }) => {
   const navItems = [
+    { id: 'home' as ViewType, label: 'Accueil', icon: HomeIcon },
     { id: 'dashboard' as ViewType, label: 'Tableau de Bord', icon: LayoutDashboard },
-    { id: 'import' as ViewType, label: 'Import FEC', icon: Upload },
+    { id: 'import' as ViewType, label: 'Import & Contrôles', icon: Upload },
     { id: 'financials' as ViewType, label: 'États Financiers', icon: FileText },
-    { id: 'risk' as ViewType, label: 'Analyse Risques', icon: AlertTriangle },
+    { id: 'risk' as ViewType, label: 'Analyse des Risques', icon: AlertTriangle },
     { id: 'qoe' as ViewType, label: 'Quality of Earnings', icon: TrendingUp },
     { id: 'deliverables' as ViewType, label: 'Livrables', icon: Download },
   ];


### PR DESCRIPTION
## Summary
- add a marketing-driven Home view with hero content and CTA buttons that navigate to key modules
- extend navigation and view handling to support the new home page as the default landing view
- tighten TypeScript typings for shared components and remove unused code, plus add a repo .gitignore

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbe72386648331a63c1d19556c73dd