### PR TITLE
Add routing with BrowserRouter and navigation updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "@supabase/supabase-js": "^2.57.4",
         "lucide-react": "^0.344.0",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-router-dom": "file:packages/react-router-dom"
       },
       "devDependencies": {
         "@eslint/js": "^9.9.1",
@@ -3369,6 +3370,10 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router-dom": {
+      "resolved": "packages/react-router-dom",
+      "link": true
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -4169,6 +4174,12 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/react-router-dom": {
+      "version": "0.0.0-local",
+      "dependencies": {
+        "react": "^18.3.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "@supabase/supabase-js": "^2.57.4",
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "file:packages/react-router-dom"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/packages/react-router-dom/dist/index.d.ts
+++ b/packages/react-router-dom/dist/index.d.ts
@@ -1,0 +1,53 @@
+import * as React from 'react';
+
+export interface NavigateOptions {
+  replace?: boolean;
+  state?: unknown;
+}
+
+export interface BrowserRouterProps {
+  children?: React.ReactNode;
+}
+
+export function BrowserRouter(props: BrowserRouterProps): React.ReactElement;
+
+export interface RouteProps {
+  path?: string;
+  element?: React.ReactElement | null;
+  index?: boolean;
+}
+
+export function Routes(props: { children?: React.ReactNode }): React.ReactElement | null;
+export function Route(props: RouteProps): null;
+
+export type NavigateFunction = (to: string, options?: NavigateOptions) => void;
+export function useNavigate(): NavigateFunction;
+
+export interface Location {
+  pathname: string;
+}
+
+export function useLocation(): Location;
+
+export interface NavLinkProps extends Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'href'> {
+  to: string;
+  className?: string | ((params: { isActive: boolean }) => string);
+  children?: React.ReactNode | ((params: { isActive: boolean }) => React.ReactNode);
+  replace?: boolean;
+}
+
+export function NavLink(props: NavLinkProps): React.ReactElement;
+
+export type LinkProps = NavLinkProps;
+
+export function Link(props: LinkProps): React.ReactElement;
+
+export default {
+  BrowserRouter,
+  Routes,
+  Route,
+  NavLink,
+  useNavigate,
+  useLocation,
+  Link
+};

--- a/packages/react-router-dom/dist/index.js
+++ b/packages/react-router-dom/dist/index.js
@@ -1,0 +1,181 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState
+} from 'react';
+
+const RouterContext = createContext(null);
+
+const normalizePath = (path) => {
+  if (typeof path !== 'string' || path.length === 0) {
+    return '/';
+  }
+  let normalized = path;
+  if (!normalized.startsWith('/')) {
+    normalized = `/${normalized}`;
+  }
+  if (normalized.length > 1 && normalized.endsWith('/')) {
+    normalized = normalized.slice(0, -1);
+  }
+  return normalized;
+};
+
+const useRouterContext = () => {
+  const context = useContext(RouterContext);
+  if (!context) {
+    throw new Error('Router context is not available. Make sure your app is wrapped with <BrowserRouter>.');
+  }
+  return context;
+};
+
+export function BrowserRouter({ children }) {
+  const initialPath = typeof window !== 'undefined' ? normalizePath(window.location.pathname) : '/';
+  const [location, setLocation] = useState(initialPath);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return undefined;
+    }
+
+    const handlePopState = () => {
+      setLocation(normalizePath(window.location.pathname));
+    };
+
+    window.addEventListener('popstate', handlePopState);
+    return () => {
+      window.removeEventListener('popstate', handlePopState);
+    };
+  }, []);
+
+  const navigate = useCallback((to, options = {}) => {
+    const target = normalizePath(to);
+    if (typeof window !== 'undefined') {
+      if (options.replace) {
+        window.history.replaceState(options.state ?? null, '', target);
+      } else {
+        window.history.pushState(options.state ?? null, '', target);
+      }
+    }
+    setLocation(target);
+  }, []);
+
+  const value = useMemo(() => ({
+    location,
+    navigate
+  }), [location, navigate]);
+
+  return React.createElement(RouterContext.Provider, { value }, children);
+}
+
+const matchPath = (routePath, currentPath) => {
+  const normalizedRoute = normalizePath(routePath);
+  if (normalizedRoute === currentPath) {
+    return true;
+  }
+  if (normalizedRoute.endsWith('/*')) {
+    const base = normalizedRoute.slice(0, -2);
+    return currentPath.startsWith(base);
+  }
+  return false;
+};
+
+export function Routes({ children }) {
+  const { location } = useRouterContext();
+  let matchedElement = null;
+
+  React.Children.forEach(children, (child) => {
+    if (matchedElement || !React.isValidElement(child)) {
+      return;
+    }
+    const { path, element, index } = child.props || {};
+    if (index && location === '/') {
+      matchedElement = element ?? null;
+      return;
+    }
+    if (typeof path === 'string' && matchPath(path, location)) {
+      matchedElement = element ?? null;
+    }
+  });
+
+  return matchedElement;
+}
+
+export function Route() {
+  return null;
+}
+
+export function useNavigate() {
+  const { navigate } = useRouterContext();
+  return navigate;
+}
+
+export function useLocation() {
+  const { location } = useRouterContext();
+  return useMemo(() => ({ pathname: location }), [location]);
+}
+
+export function NavLink({ to, className, children, replace = false, ...rest }) {
+  const { location, navigate } = useRouterContext();
+  const normalizedTo = normalizePath(to);
+  const isActive = location === normalizedTo;
+  const resolvedClassName = typeof className === 'function'
+    ? className({ isActive })
+    : className;
+
+  const { onClick, target, ...anchorProps } = rest;
+
+  const handleClick = (event) => {
+    if (onClick) {
+      onClick(event);
+    }
+
+    if (
+      event.defaultPrevented ||
+      event.button !== 0 ||
+      target === '_blank' ||
+      event.metaKey ||
+      event.altKey ||
+      event.ctrlKey ||
+      event.shiftKey
+    ) {
+      return;
+    }
+
+    event.preventDefault();
+    navigate(normalizedTo, { replace });
+  };
+
+  const renderedChildren = typeof children === 'function'
+    ? children({ isActive })
+    : children;
+
+  return React.createElement(
+    'a',
+    {
+      ...anchorProps,
+      href: normalizedTo,
+      target,
+      onClick: handleClick,
+      className: resolvedClassName,
+      'aria-current': isActive ? 'page' : undefined
+    },
+    renderedChildren
+  );
+}
+
+export function Link(props) {
+  return NavLink({ ...props, className: props.className });
+}
+
+export default {
+  BrowserRouter,
+  Routes,
+  Route,
+  NavLink,
+  useNavigate,
+  useLocation,
+  Link
+};

--- a/packages/react-router-dom/package.json
+++ b/packages/react-router-dom/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "react-router-dom",
+  "version": "0.0.0-local",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "dependencies": {
+    "react": "^18.3.1"
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import React from 'react';
+import { Routes, Route } from 'react-router-dom';
 import { Navigation } from './components/Navigation';
 import { Dashboard } from './components/Dashboard';
 import { FileImport } from './components/FileImport';
@@ -6,41 +7,24 @@ import { FinancialStatements } from './components/FinancialStatements';
 import { RiskAnalysis } from './components/RiskAnalysis';
 import { QualityOfEarnings } from './components/QualityOfEarnings';
 import { Deliverables } from './components/Deliverables';
-import { AppProvider } from './context/AppContext';
-
-export type ViewType = 'dashboard' | 'import' | 'financials' | 'risk' | 'qoe' | 'deliverables';
+import { viewPaths } from './routes';
 
 function App() {
-  const [currentView, setCurrentView] = useState<ViewType>('dashboard');
-
-  const renderView = () => {
-    switch (currentView) {
-      case 'dashboard':
-        return <Dashboard />;
-      case 'import':
-        return <FileImport />;
-      case 'financials':
-        return <FinancialStatements />;
-      case 'risk':
-        return <RiskAnalysis />;
-      case 'qoe':
-        return <QualityOfEarnings />;
-      case 'deliverables':
-        return <Deliverables />;
-      default:
-        return <Dashboard />;
-    }
-  };
-
   return (
-    <AppProvider>
-      <div className="min-h-screen bg-gray-50">
-        <Navigation currentView={currentView} onViewChange={setCurrentView} />
-        <main className="pt-16">
-          {renderView()}
-        </main>
-      </div>
-    </AppProvider>
+    <div className="min-h-screen bg-gray-50">
+      <Navigation />
+      <main className="pt-16">
+        <Routes>
+          <Route path={viewPaths.dashboard} element={<Dashboard />} />
+          <Route path={viewPaths.import} element={<FileImport />} />
+          <Route path={viewPaths.financials} element={<FinancialStatements />} />
+          <Route path={viewPaths.risk} element={<RiskAnalysis />} />
+          <Route path={viewPaths.qoe} element={<QualityOfEarnings />} />
+          <Route path={viewPaths.deliverables} element={<Deliverables />} />
+          <Route path="*" element={<Dashboard />} />
+        </Routes>
+      </main>
+    </div>
   );
 }
 

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,30 +1,27 @@
 import React from 'react';
-import { ViewType } from '../App';
-import { 
-  LayoutDashboard, 
-  Upload, 
-  FileText, 
-  AlertTriangle, 
-  TrendingUp, 
+import { NavLink } from 'react-router-dom';
+import type { ViewType } from '../routes';
+import { viewPaths } from '../routes';
+import {
+  LayoutDashboard,
+  Upload,
+  FileText,
+  AlertTriangle,
+  TrendingUp,
   Download,
   Zap
 } from 'lucide-react';
 
-interface NavigationProps {
-  currentView: ViewType;
-  onViewChange: (view: ViewType) => void;
-}
+const navItems: { id: ViewType; label: string; icon: React.ComponentType<{ className?: string }> }[] = [
+  { id: 'dashboard', label: 'Tableau de Bord', icon: LayoutDashboard },
+  { id: 'import', label: 'Import FEC', icon: Upload },
+  { id: 'financials', label: 'États Financiers', icon: FileText },
+  { id: 'risk', label: 'Analyse Risques', icon: AlertTriangle },
+  { id: 'qoe', label: 'Quality of Earnings', icon: TrendingUp },
+  { id: 'deliverables', label: 'Livrables', icon: Download }
+];
 
-export const Navigation: React.FC<NavigationProps> = ({ currentView, onViewChange }) => {
-  const navItems = [
-    { id: 'dashboard' as ViewType, label: 'Tableau de Bord', icon: LayoutDashboard },
-    { id: 'import' as ViewType, label: 'Import FEC', icon: Upload },
-    { id: 'financials' as ViewType, label: 'États Financiers', icon: FileText },
-    { id: 'risk' as ViewType, label: 'Analyse Risques', icon: AlertTriangle },
-    { id: 'qoe' as ViewType, label: 'Quality of Earnings', icon: TrendingUp },
-    { id: 'deliverables' as ViewType, label: 'Livrables', icon: Download },
-  ];
-
+export const Navigation: React.FC = () => {
   return (
     <nav className="fixed top-0 left-0 right-0 bg-white border-b border-gray-200 z-50">
       <div className="max-w-7xl mx-auto px-4">
@@ -34,25 +31,26 @@ export const Navigation: React.FC<NavigationProps> = ({ currentView, onViewChang
             <h1 className="text-xl font-bold text-gray-900">Pégase</h1>
             <span className="text-sm text-gray-500">Due Diligence Platform</span>
           </div>
-          
+
           <div className="flex space-x-1">
             {navItems.map((item) => {
               const Icon = item.icon;
-              const isActive = currentView === item.id;
-              
+
               return (
-                <button
+                <NavLink
                   key={item.id}
-                  onClick={() => onViewChange(item.id)}
-                  className={`px-3 py-2 rounded-md text-sm font-medium transition-colors duration-200 flex items-center space-x-2 ${
-                    isActive
-                      ? 'bg-blue-100 text-blue-700'
-                      : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
-                  }`}
+                  to={viewPaths[item.id]}
+                  className={({ isActive }) =>
+                    `px-3 py-2 rounded-md text-sm font-medium transition-colors duration-200 flex items-center space-x-2 ${
+                      isActive
+                        ? 'bg-blue-100 text-blue-700'
+                        : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
+                    }`
+                  }
                 >
                   <Icon className="h-4 w-4" />
                   <span className="hidden md:block">{item.label}</span>
-                </button>
+                </NavLink>
               );
             })}
           </div>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,16 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
 import App from './App.tsx';
 import './index.css';
+import { AppProvider } from './context/AppContext';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <AppProvider>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </AppProvider>
   </StrictMode>
 );

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,0 +1,16 @@
+export type ViewType =
+  | 'dashboard'
+  | 'import'
+  | 'financials'
+  | 'risk'
+  | 'qoe'
+  | 'deliverables';
+
+export const viewPaths: Record<ViewType, string> = {
+  dashboard: '/',
+  import: '/import',
+  financials: '/financials',
+  risk: '/risk',
+  qoe: '/qoe',
+  deliverables: '/deliverables'
+};


### PR DESCRIPTION
## Summary
- add a local `react-router-dom` package that provides the router primitives needed for view routing
- wrap the application with `BrowserRouter` inside the global `AppProvider` and replace the `useState` view switch with declarative routes
- update the navigation component to drive navigation via router links and centralize view path definitions

## Testing
- npm run build
- npm run lint *(fails: existing @typescript-eslint errors in legacy components)*

------
https://chatgpt.com/codex/tasks/task_e_68cbe7265af88331828d553b1f1d576f