### PR TITLE
Add FEC processing service and integrate API call

### DIFF
--- a/src/components/FileImport.tsx
+++ b/src/components/FileImport.tsx
@@ -1,13 +1,36 @@
 import React, { useState } from 'react';
 import { Upload, FileText, CheckCircle, AlertCircle, Download } from 'lucide-react';
+import { processFec, FecControlResult } from '../services/fec';
+
+type FileStatus = 'uploaded' | 'processed' | 'error';
+
+interface ImportedFile {
+  file: File;
+  name: string;
+  size: number;
+  type: string;
+  status: FileStatus;
+  controls: FecControlResult[];
+  warnings: string[];
+  processingId?: string;
+  error?: string;
+}
 
 export const FileImport: React.FC = () => {
-  const [files, setFiles] = useState<any[]>([]);
+  const [files, setFiles] = useState<ImportedFile[]>([]);
   const [isProcessing, setIsProcessing] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const handleFileUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
     const uploadedFiles = Array.from(event.target.files || []);
+    if (uploadedFiles.length === 0) {
+      return;
+    }
+
+    setErrorMessage(null);
+
     const newFiles = uploadedFiles.map(file => ({
+      file,
       name: file.name,
       size: file.size,
       type: file.type,
@@ -15,35 +38,70 @@ export const FileImport: React.FC = () => {
       controls: [],
       warnings: []
     }));
-    setFiles([...files, ...newFiles]);
+    setFiles(prevFiles => [...prevFiles, ...newFiles]);
+
+    if (event.target) {
+      event.target.value = '';
+    }
   };
 
-  const processFiles = () => {
+  const processFiles = async () => {
+    const pendingIndices = files.reduce<number[]>((accumulator, file, index) => {
+      if (file.status === 'uploaded') {
+        accumulator.push(index);
+      }
+      return accumulator;
+    }, []);
+
+    if (pendingIndices.length === 0) {
+      return;
+    }
+
     setIsProcessing(true);
-    
-    // Simulate processing
-    setTimeout(() => {
-      const processedFiles = files.map(file => ({
-        ...file,
-        status: 'processed',
-        controls: [
-          { name: 'Format FEC', status: 'passed', message: 'Format conforme à la réglementation' },
-          { name: 'Équilibre comptable', status: 'passed', message: 'Débit = Crédit validé' },
-          { name: 'Cohérence dates', status: file.name.includes('FEC') ? 'warning' : 'passed', 
-            message: file.name.includes('FEC') ? '12 écritures avec dates suspectes' : 'Chronologie respectée' },
-          { name: 'Doublons', status: 'passed', message: 'Aucun doublon détecté' },
-          { name: 'Lettrage', status: 'warning', message: '134 comptes clients non lettrés' }
-        ],
-        warnings: file.name.includes('FEC') ? [
-          'Pic d\'écritures en décembre (+35% vs moyenne)',
-          'Comptes d\'attente 471000 solde élevé (45K€)',
-          'Libellés suspects détectés (3 occurrences)'
-        ] : []
-      }));
-      
-      setFiles(processedFiles);
+    setErrorMessage(null);
+
+    try {
+      const filesToSend = pendingIndices.map(index => files[index].file);
+      const results = await processFec(filesToSend);
+
+      if (results.length !== pendingIndices.length) {
+        throw new Error('Le service FEC a retourné un nombre de résultats inattendu.');
+      }
+
+      setFiles(prevFiles => {
+        const updatedFiles = [...prevFiles];
+
+        pendingIndices.forEach((fileIndex, resultIndex) => {
+          const result = results[resultIndex];
+          updatedFiles[fileIndex] = {
+            ...updatedFiles[fileIndex],
+            status: 'processed',
+            controls: result.controls,
+            warnings: result.warnings,
+            processingId: result.processingId,
+            error: undefined,
+          };
+        });
+
+        return updatedFiles;
+      });
+    } catch (error) {
+      console.error('FEC processing failed', error);
+      const message =
+        error instanceof Error
+          ? error.message
+          : 'Une erreur est survenue lors du traitement des fichiers.';
+      setErrorMessage(message);
+      setFiles(prevFiles =>
+        prevFiles.map(file =>
+          file.status === 'uploaded'
+            ? { ...file, status: 'error', error: message, controls: [], warnings: [] }
+            : file
+        )
+      );
+    } finally {
       setIsProcessing(false);
-    }, 2000);
+    }
   };
 
   const downloadTemplate = () => {
@@ -51,8 +109,30 @@ export const FileImport: React.FC = () => {
     alert('Téléchargement du template de mapping PCG...');
   };
 
+  const statusLabels: Record<FileStatus, string> = {
+    processed: 'Traité',
+    uploaded: 'En attente',
+    error: 'Erreur',
+  };
+
+  const statusClasses: Record<FileStatus, string> = {
+    processed: 'bg-green-100 text-green-800',
+    uploaded: 'bg-yellow-100 text-yellow-800',
+    error: 'bg-red-100 text-red-800',
+  };
+
+  const hasPendingFiles = files.some(file => file.status === 'uploaded');
+
   return (
     <div className="max-w-6xl mx-auto px-4 py-6 space-y-6">
+      {errorMessage && (
+        <div
+          role="alert"
+          className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700"
+        >
+          {errorMessage}
+        </div>
+      )}
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold text-gray-900">Import & Contrôles FEC</h1>
@@ -99,7 +179,7 @@ export const FileImport: React.FC = () => {
         <div className="bg-white rounded-lg border border-gray-200 p-6">
           <div className="flex items-center justify-between mb-4">
             <h3 className="text-lg font-semibold text-gray-900">Fichiers importés</h3>
-            {!isProcessing && files.some(f => f.status === 'uploaded') && (
+            {!isProcessing && hasPendingFiles && (
               <button
                 onClick={processFiles}
                 className="px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors"
@@ -132,12 +212,13 @@ export const FileImport: React.FC = () => {
                     {file.status === 'processed' && (
                       <CheckCircle className="h-5 w-5 text-green-600" />
                     )}
-                    <span className={`px-2 py-1 rounded text-sm font-medium ${
-                      file.status === 'processed' 
-                        ? 'bg-green-100 text-green-800' 
-                        : 'bg-yellow-100 text-yellow-800'
-                    }`}>
-                      {file.status === 'processed' ? 'Traité' : 'En attente'}
+                    {file.status === 'error' && (
+                      <AlertCircle className="h-5 w-5 text-red-600" />
+                    )}
+                    <span
+                      className={`px-2 py-1 rounded text-sm font-medium ${statusClasses[file.status]}`}
+                    >
+                      {statusLabels[file.status]}
                     </span>
                   </div>
                 </div>
@@ -146,12 +227,16 @@ export const FileImport: React.FC = () => {
                   <div className="mt-4">
                     <h5 className="font-medium text-gray-900 mb-2">Contrôles automatiques</h5>
                     <div className="space-y-2">
-                      {file.controls.map((control: any, controlIndex: number) => (
+                      {file.controls.map((control, controlIndex) => (
                         <div key={controlIndex} className="flex items-center space-x-2">
-                          {control.status === 'passed' ? (
+                          {control.status === 'passed' && (
                             <CheckCircle className="h-4 w-4 text-green-600" />
-                          ) : (
+                          )}
+                          {control.status === 'warning' && (
                             <AlertCircle className="h-4 w-4 text-yellow-600" />
+                          )}
+                          {control.status === 'failed' && (
+                            <AlertCircle className="h-4 w-4 text-red-600" />
                           )}
                           <span className="text-sm font-medium">{control.name}:</span>
                           <span className="text-sm text-gray-600">{control.message}</span>
@@ -168,13 +253,17 @@ export const FileImport: React.FC = () => {
                       Alertes détectées
                     </h5>
                     <ul className="space-y-1">
-                      {file.warnings.map((warning: string, warningIndex: number) => (
+                      {file.warnings.map((warning, warningIndex) => (
                         <li key={warningIndex} className="text-sm text-yellow-700">
                           • {warning}
                         </li>
                       ))}
                     </ul>
                   </div>
+                )}
+
+                {file.status === 'error' && file.error && (
+                  <p className="mt-4 text-sm text-red-600">{file.error}</p>
                 )}
               </div>
             ))}

--- a/src/services/fec.ts
+++ b/src/services/fec.ts
@@ -1,0 +1,85 @@
+export type ControlStatus = 'passed' | 'warning' | 'failed';
+
+export interface FecControlResult {
+  name: string;
+  status: ControlStatus;
+  message: string;
+}
+
+export interface FecProcessedFile {
+  fileName: string;
+  processingId: string;
+  controls: FecControlResult[];
+  warnings: string[];
+}
+
+interface ProcessFecApiResponse {
+  files: Array<{
+    fileName?: string;
+    originalName?: string;
+    processingId: string;
+    controls?: FecControlResult[];
+    warnings?: string[];
+  }>;
+}
+
+const buildEndpoint = () => {
+  const baseUrl = import.meta.env.VITE_API_URL;
+  if (!baseUrl) {
+    return '/api/fec/process';
+  }
+
+  const normalizedBase = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
+  return `${normalizedBase}/fec/process`;
+};
+
+export async function processFec(files: File[]): Promise<FecProcessedFile[]> {
+  if (files.length === 0) {
+    return [];
+  }
+
+  const formData = new FormData();
+  files.forEach(file => {
+    formData.append('files', file);
+  });
+
+  const response = await fetch(buildEndpoint(), {
+    method: 'POST',
+    body: formData,
+  });
+
+  if (!response.ok) {
+    const errorMessage = await response.text().catch(() => undefined);
+    throw new Error(errorMessage || 'Le service FEC est indisponible.');
+  }
+
+  let payload: ProcessFecApiResponse;
+  try {
+    payload = await response.json();
+  } catch {
+    throw new Error("La réponse du service FEC n'est pas valide.");
+  }
+
+  if (!payload || !Array.isArray(payload.files)) {
+    throw new Error("La réponse du service FEC n'est pas valide.");
+  }
+
+  return payload.files.map(result => {
+    const fileName = result.fileName ?? result.originalName;
+
+    if (!fileName) {
+      throw new Error('La réponse du service FEC est incomplète (nom de fichier manquant).');
+    }
+
+    if (!result.processingId) {
+      throw new Error('La réponse du service FEC est incomplète (identifiant de traitement manquant).');
+    }
+
+    return {
+      fileName,
+      processingId: result.processingId,
+      controls: result.controls ?? [],
+      warnings: result.warnings ?? [],
+    };
+  });
+}


### PR DESCRIPTION
## Summary
- add a FEC service module that posts uploaded files to the backend API and returns processing details
- call the new service from FileImport with typed file state so each entry stores controls, warnings, and the processing id
- surface API failures with the existing spinner and a user-visible error banner instead of silent timeouts

## Testing
- npm run lint *(fails: pre-existing lint errors in ChartCard.tsx and Deliverables.tsx)*
- npx eslint src/components/FileImport.tsx src/services/fec.ts


------
https://chatgpt.com/codex/tasks/task_e_68cbe727db9c83318be3873c619f2b50