### PR TITLE
feat: integrate router with home landing page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "@supabase/supabase-js": "^2.57.4",
         "lucide-react": "^0.344.0",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-router-dom": "file:vendor/react-router-dom"
       },
       "devDependencies": {
         "@eslint/js": "^9.9.1",
@@ -4170,6 +4171,15 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "vendor/react-router-dom": {
+      "name": "react-router-dom",
+      "version": "0.0.0-shim"
+    },
+    "node_modules/react-router-dom": {
+      "version": "0.0.0-shim",
+      "resolved": "file:vendor/react-router-dom",
+      "link": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "@supabase/supabase-js": "^2.57.4",
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "file:vendor/react-router-dom"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,7 @@
-import React, { useState } from 'react';
+import React from 'react';
+import { Routes, Route } from 'react-router-dom';
 import { Navigation } from './components/Navigation';
+import { Home } from './components/Home';
 import { Dashboard } from './components/Dashboard';
 import { FileImport } from './components/FileImport';
 import { FinancialStatements } from './components/FinancialStatements';
@@ -9,37 +11,33 @@ import { Deliverables } from './components/Deliverables';
 import { AppProvider } from './context/AppContext';
 import { ThemeProvider, useTheme } from './context/ThemeContext';
 
-export type ViewType = 'dashboard' | 'import' | 'financials' | 'risk' | 'qoe' | 'deliverables';
+export type ViewType =
+  | 'home'
+  | 'dashboard'
+  | 'import'
+  | 'financials'
+  | 'risk'
+  | 'qoe'
+  | 'deliverables';
 
 const AppLayout: React.FC = () => {
-  const [currentView, setCurrentView] = useState<ViewType>('dashboard');
   const { theme } = useTheme();
-
-  const renderView = () => {
-    switch (currentView) {
-      case 'dashboard':
-        return <Dashboard />;
-      case 'import':
-        return <FileImport />;
-      case 'financials':
-        return <FinancialStatements />;
-      case 'risk':
-        return <RiskAnalysis />;
-      case 'qoe':
-        return <QualityOfEarnings />;
-      case 'deliverables':
-        return <Deliverables />;
-      default:
-        return <Dashboard />;
-    }
-  };
 
   return (
     <div className={theme === 'dark' ? 'dark' : ''}>
       <div className="min-h-screen bg-gray-50 text-gray-900 transition-colors duration-300 dark:bg-slate-950 dark:text-slate-100">
-        <Navigation currentView={currentView} onViewChange={setCurrentView} />
+        <Navigation />
         <main className="pt-16">
-          {renderView()}
+          <Routes>
+            <Route path="/" element={<Home />} />
+            <Route path="/dashboard" element={<Dashboard />} />
+            <Route path="/import" element={<FileImport />} />
+            <Route path="/financials" element={<FinancialStatements />} />
+            <Route path="/risk" element={<RiskAnalysis />} />
+            <Route path="/qoe" element={<QualityOfEarnings />} />
+            <Route path="/deliverables" element={<Deliverables />} />
+            <Route path="*" element={<Home />} />
+          </Routes>
         </main>
       </div>
     </div>

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import {
+  AlertTriangle,
+  ArrowRight,
+  Download,
+  FileText,
+  LayoutDashboard,
+  TrendingUp,
+  Upload,
+} from 'lucide-react';
+
+const modules = [
+  {
+    id: 'dashboard',
+    title: 'Tableau de Bord',
+    description: 'Suivez les indicateurs clés et les signaux d’alerte en temps réel.',
+    icon: LayoutDashboard,
+    to: '/dashboard',
+  },
+  {
+    id: 'import',
+    title: 'Import FEC',
+    description: 'Chargez vos fichiers FEC en toute sécurité et préparez-les pour l’analyse.',
+    icon: Upload,
+    to: '/import',
+  },
+  {
+    id: 'financials',
+    title: 'États Financiers',
+    description: 'Analysez bilans, comptes de résultat et flux de trésorerie en quelques clics.',
+    icon: FileText,
+    to: '/financials',
+  },
+  {
+    id: 'risk',
+    title: 'Analyse Risques',
+    description: 'Identifiez les zones de vigilance grâce à une notation des risques automatisée.',
+    icon: AlertTriangle,
+    to: '/risk',
+  },
+  {
+    id: 'qoe',
+    title: 'Quality of Earnings',
+    description: 'Évaluez la récurrence des performances et la qualité des résultats publiés.',
+    icon: TrendingUp,
+    to: '/qoe',
+  },
+  {
+    id: 'deliverables',
+    title: 'Livrables',
+    description: 'Générez vos rapports d’audit personnalisés et partagez-les en un clic.',
+    icon: Download,
+    to: '/deliverables',
+  },
+] as const;
+
+export const Home: React.FC = () => {
+  return (
+    <div className="relative overflow-hidden">
+      <section className="bg-gradient-to-br from-blue-50 via-white to-purple-50 dark:from-slate-900 dark:via-slate-950 dark:to-blue-950">
+        <div className="max-w-6xl mx-auto px-4 py-24 sm:py-32">
+          <div className="max-w-3xl">
+            <span className="inline-flex items-center rounded-full bg-blue-100 px-3 py-1 text-sm font-medium text-blue-700 dark:bg-blue-500/20 dark:text-blue-100">
+              Pégase Platform
+            </span>
+            <h1 className="mt-6 text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl dark:text-white">
+              Accélérez vos due diligences financières avec un copilote intelligent
+            </h1>
+            <p className="mt-6 text-lg text-gray-600 dark:text-slate-300">
+              Centralisez vos analyses, automatisez les contrôles et collaborez avec votre équipe sur une plateforme conçue pour les cabinets de conseil et les fonds d’investissement.
+            </p>
+            <div className="mt-10 flex flex-wrap gap-4">
+              <Link
+                to="/dashboard"
+                className="inline-flex items-center justify-center rounded-md bg-blue-600 px-6 py-3 text-base font-semibold text-white shadow-lg shadow-blue-600/20 transition hover:bg-blue-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+              >
+                Accéder au tableau de bord
+                <ArrowRight className="ml-2 h-4 w-4" aria-hidden="true" />
+              </Link>
+              <Link
+                to="/import"
+                className="inline-flex items-center justify-center rounded-md border border-gray-300 px-6 py-3 text-base font-semibold text-gray-900 transition hover:border-blue-500 hover:text-blue-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:border-slate-700 dark:text-slate-100 dark:hover:border-blue-500 dark:hover:text-blue-200"
+              >
+                Importer un FEC
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="relative -mt-12 pb-24 sm:-mt-20">
+        <div className="max-w-6xl mx-auto px-4">
+          <div className="grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
+            {modules.map((module) => {
+              const Icon = module.icon;
+              return (
+                <Link
+                  key={module.id}
+                  to={module.to}
+                  className="group relative flex h-full flex-col rounded-2xl border border-gray-200 bg-white p-6 shadow-sm transition hover:-translate-y-1 hover:shadow-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:border-slate-800 dark:bg-slate-900/60"
+                >
+                  <div className="flex items-center justify-between">
+                    <span className="inline-flex h-12 w-12 items-center justify-center rounded-xl bg-blue-100 text-blue-700 transition group-hover:bg-blue-600 group-hover:text-white dark:bg-blue-500/20 dark:text-blue-100 dark:group-hover:bg-blue-500">
+                      <Icon className="h-6 w-6" aria-hidden="true" />
+                    </span>
+                    <ArrowRight className="h-5 w-5 text-gray-400 transition group-hover:text-blue-600 dark:text-slate-500 dark:group-hover:text-blue-300" aria-hidden="true" />
+                  </div>
+                  <div className="mt-6">
+                    <h2 className="text-xl font-semibold text-gray-900 dark:text-white">{module.title}</h2>
+                    <p className="mt-3 text-sm text-gray-600 dark:text-slate-300">{module.description}</p>
+                  </div>
+                  <span className="mt-8 inline-flex items-center text-sm font-semibold text-blue-600 transition group-hover:text-blue-700 dark:text-blue-300 dark:group-hover:text-blue-200">
+                    Découvrir le module
+                    <ArrowRight className="ml-1 h-4 w-4" aria-hidden="true" />
+                  </span>
+                </Link>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+};

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,66 +1,72 @@
 import React from 'react';
+import { NavLink } from 'react-router-dom';
 import { ViewType } from '../App';
 import {
-  LayoutDashboard,
-  Upload,
-  FileText,
   AlertTriangle,
-  TrendingUp,
   Download,
-  Zap,
+  FileText,
+  Home as HomeIcon,
+  LayoutDashboard,
   Moon,
-  Sun
+  Sun,
+  TrendingUp,
+  Upload,
+  Zap,
 } from 'lucide-react';
 import { useTheme } from '../context/ThemeContext';
 
-interface NavigationProps {
-  currentView: ViewType;
-  onViewChange: (view: ViewType) => void;
-}
+type NavigationItem = {
+  id: ViewType;
+  label: string;
+  icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+  path: string;
+  end?: boolean;
+};
 
-export const Navigation: React.FC<NavigationProps> = ({ currentView, onViewChange }) => {
+const navigationItems: NavigationItem[] = [
+  { id: 'home', label: 'Accueil', icon: HomeIcon, path: '/', end: true },
+  { id: 'dashboard', label: 'Tableau de Bord', icon: LayoutDashboard, path: '/dashboard' },
+  { id: 'import', label: 'Import FEC', icon: Upload, path: '/import' },
+  { id: 'financials', label: 'États Financiers', icon: FileText, path: '/financials' },
+  { id: 'risk', label: 'Analyse Risques', icon: AlertTriangle, path: '/risk' },
+  { id: 'qoe', label: 'Quality of Earnings', icon: TrendingUp, path: '/qoe' },
+  { id: 'deliverables', label: 'Livrables', icon: Download, path: '/deliverables' },
+];
+
+export const Navigation: React.FC = () => {
   const { theme, toggleTheme } = useTheme();
   const isDarkMode = theme === 'dark';
-
-  const navItems = [
-    { id: 'dashboard' as ViewType, label: 'Tableau de Bord', icon: LayoutDashboard },
-    { id: 'import' as ViewType, label: 'Import FEC', icon: Upload },
-    { id: 'financials' as ViewType, label: 'États Financiers', icon: FileText },
-    { id: 'risk' as ViewType, label: 'Analyse Risques', icon: AlertTriangle },
-    { id: 'qoe' as ViewType, label: 'Quality of Earnings', icon: TrendingUp },
-    { id: 'deliverables' as ViewType, label: 'Livrables', icon: Download },
-  ];
 
   return (
     <nav className="fixed top-0 left-0 right-0 bg-white border-b border-gray-200 z-50 dark:bg-slate-900 dark:border-slate-800">
       <div className="max-w-7xl mx-auto px-4">
         <div className="flex items-center justify-between h-16">
           <div className="flex items-center space-x-3">
-            <Zap className="h-8 w-8 text-blue-600" />
+            <Zap className="h-8 w-8 text-blue-600" aria-hidden="true" />
             <h1 className="text-xl font-bold text-gray-900 dark:text-white">Pégase</h1>
             <span className="text-sm text-gray-500 dark:text-slate-300">Due Diligence Platform</span>
           </div>
 
           <div className="flex items-center space-x-1">
-            {navItems.map((item) => {
+            {navigationItems.map((item) => {
               const Icon = item.icon;
-              const isActive = currentView === item.id;
 
               return (
-                <button
+                <NavLink
                   key={item.id}
-                  type="button"
-                  onClick={() => onViewChange(item.id)}
-                  aria-current={isActive ? 'page' : undefined}
-                  className={`px-3 py-2 rounded-md text-sm font-medium transition-colors duration-200 flex items-center space-x-2 ${
-                    isActive
-                      ? 'bg-blue-100 text-blue-700 dark:bg-blue-500/20 dark:text-blue-100'
-                      : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100 dark:text-slate-300 dark:hover:text-white dark:hover:bg-slate-800'
-                  }`}
+                  to={item.path}
+                  end={item.end}
+                  className={({ isActive }) =>
+                    `px-3 py-2 rounded-md text-sm font-medium transition-colors duration-200 flex items-center space-x-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
+                      isActive
+                        ? 'bg-blue-100 text-blue-700 dark:bg-blue-500/20 dark:text-blue-100'
+                        : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100 dark:text-slate-300 dark:hover:text-white dark:hover:bg-slate-800'
+                    }`
+                  }
                 >
-                  <Icon className="h-4 w-4" />
+                  <Icon className="h-4 w-4" aria-hidden="true" />
                   <span className="hidden md:block">{item.label}</span>
-                </button>
+                </NavLink>
               );
             })}
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
 import App from './App.tsx';
 import './index.css';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>
 );

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -13,6 +13,10 @@
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": {
+      "react-router-dom": ["./vendor/react-router-dom/index"]
+    },
 
     /* Linting */
     "strict": true,

--- a/vendor/react-router-dom/index.tsx
+++ b/vendor/react-router-dom/index.tsx
@@ -1,0 +1,287 @@
+/* eslint-disable react-refresh/only-export-components */
+import React, {
+  AnchorHTMLAttributes,
+  FC,
+  MouseEvent,
+  ReactNode,
+  createContext,
+  forwardRef,
+  isValidElement,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+
+type RouterLocation = {
+  pathname: string;
+  search: string;
+  hash: string;
+};
+
+type NavigateOptions = {
+  replace?: boolean;
+};
+
+type RouterContextValue = {
+  location: RouterLocation;
+  navigate: (to: string, options?: NavigateOptions) => void;
+};
+
+const RouterContext = createContext<RouterContextValue | null>(null);
+
+const getCurrentLocation = (): RouterLocation => {
+  if (typeof window === 'undefined') {
+    return { pathname: '/', search: '', hash: '' };
+  }
+
+  return {
+    pathname: window.location.pathname || '/',
+    search: window.location.search || '',
+    hash: window.location.hash || '',
+  };
+};
+
+const normalizePath = (path: string): string => {
+  if (!path) {
+    return '/';
+  }
+
+  const startsWithSlash = path.startsWith('/');
+  const sanitized = path.replace(/\/+$/, '');
+  const value = sanitized === '' ? '/' : sanitized;
+  return startsWithSlash ? value : `/${value}`;
+};
+
+const matchRoutePath = (path: string, pathname: string): boolean => {
+  if (path === '*') {
+    return true;
+  }
+
+  const normalizedPath = normalizePath(path);
+  const normalizedLocation = normalizePath(pathname);
+
+  return normalizedPath === normalizedLocation;
+};
+
+const matchNavPath = (to: string, pathname: string, end?: boolean): boolean => {
+  const normalizedTo = normalizePath(to);
+  const normalizedLocation = normalizePath(pathname);
+
+  if (normalizedTo === '/') {
+    return normalizedLocation === '/';
+  }
+
+  if (end) {
+    return normalizedLocation === normalizedTo;
+  }
+
+  return (
+    normalizedLocation === normalizedTo ||
+    normalizedLocation.startsWith(`${normalizedTo}/`)
+  );
+};
+
+const shouldHandleLinkClick = (event: MouseEvent<HTMLAnchorElement>, target?: string): boolean => {
+  return (
+    !event.defaultPrevented &&
+    event.button === 0 &&
+    (!target || target === '_self') &&
+    !event.metaKey &&
+    !event.altKey &&
+    !event.ctrlKey &&
+    !event.shiftKey
+  );
+};
+
+const useRouterContext = (): RouterContextValue => {
+  const context = useContext(RouterContext);
+
+  if (!context) {
+    throw new Error('Router components must be used within a BrowserRouter.');
+  }
+
+  return context;
+};
+
+export const BrowserRouter: FC<{ children: ReactNode }> = ({ children }) => {
+  const [location, setLocation] = useState<RouterLocation>(() => getCurrentLocation());
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const handlePopState = () => {
+      setLocation(getCurrentLocation());
+    };
+
+    window.addEventListener('popstate', handlePopState);
+
+    return () => {
+      window.removeEventListener('popstate', handlePopState);
+    };
+  }, []);
+
+  const navigate = useCallback((to: string, options?: NavigateOptions) => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const targetUrl = new URL(to, window.location.origin);
+    const href = `${targetUrl.pathname}${targetUrl.search}${targetUrl.hash}`;
+
+    if (options?.replace) {
+      window.history.replaceState(null, '', href);
+    } else {
+      window.history.pushState(null, '', href);
+    }
+
+    setLocation(getCurrentLocation());
+  }, []);
+
+  const contextValue = useMemo(
+    () => ({ location, navigate }),
+    [location, navigate]
+  );
+
+  return <RouterContext.Provider value={contextValue}>{children}</RouterContext.Provider>;
+};
+
+interface RoutesProps {
+  children: ReactNode;
+}
+
+interface RouteProps {
+  path: string;
+  element: ReactNode;
+}
+
+export const Route: FC<RouteProps> = () => null;
+
+export const Routes: FC<RoutesProps> = ({ children }) => {
+  const { location } = useRouterContext();
+  let match: ReactNode = null;
+
+  React.Children.forEach(children, (child) => {
+    if (match !== null) {
+      return;
+    }
+
+    if (!isValidElement<RouteProps>(child)) {
+      return;
+    }
+
+    const { path, element } = child.props;
+
+    if (matchRoutePath(path, location.pathname)) {
+      match = element;
+    }
+  });
+
+  return <>{match}</>;
+};
+
+type ClassNameResolver = (props: { isActive: boolean }) => string | undefined;
+
+type NavLinkProps = {
+  to: string;
+  end?: boolean;
+  className?: string | ClassNameResolver;
+  style?: React.CSSProperties | ((props: { isActive: boolean }) => React.CSSProperties | undefined);
+  children?: ReactNode;
+} & Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'className' | 'children' | 'style' | 'href'>;
+
+export const NavLink = forwardRef<HTMLAnchorElement, NavLinkProps>(
+  (
+    { to, end, className, style, onClick, children, target, ...rest },
+    ref
+  ) => {
+    const { location, navigate } = useRouterContext();
+    const isActive = matchNavPath(to, location.pathname, end);
+
+    const resolvedClassName =
+      typeof className === 'function'
+        ? className({ isActive }) || undefined
+        : className;
+
+    const resolvedStyle =
+      typeof style === 'function' ? style({ isActive }) : style;
+
+    const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
+      if (onClick) {
+        onClick(event);
+      }
+
+      if (!shouldHandleLinkClick(event, target)) {
+        return;
+      }
+
+      event.preventDefault();
+      navigate(to);
+    };
+
+    return (
+      <a
+        {...rest}
+        ref={ref}
+        href={to}
+        target={target}
+        onClick={handleClick}
+        aria-current={isActive ? 'page' : undefined}
+        className={resolvedClassName}
+        style={resolvedStyle}
+      >
+        {children}
+      </a>
+    );
+  }
+);
+
+NavLink.displayName = 'NavLink';
+
+type LinkProps = {
+  to: string;
+  children?: ReactNode;
+} & Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'href' | 'children'>;
+
+export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
+  ({ to, onClick, target, children, ...rest }, ref) => {
+    const { navigate } = useRouterContext();
+
+    const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
+      if (onClick) {
+        onClick(event);
+      }
+
+      if (!shouldHandleLinkClick(event, target)) {
+        return;
+      }
+
+      event.preventDefault();
+      navigate(to);
+    };
+
+    return (
+      <a
+        {...rest}
+        ref={ref}
+        href={to}
+        target={target}
+        onClick={handleClick}
+      >
+        {children}
+      </a>
+    );
+  }
+);
+
+Link.displayName = 'Link';
+
+export const useLocation = (): RouterLocation => useRouterContext().location;
+
+export const useNavigate = (): ((to: string, options?: NavigateOptions) => void) =>
+  useRouterContext().navigate;
+
+export type { RouterLocation as Location, NavigateOptions };

--- a/vendor/react-router-dom/package.json
+++ b/vendor/react-router-dom/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "react-router-dom",
+  "version": "0.0.0-shim",
+  "type": "module",
+  "main": "./index.tsx",
+  "module": "./index.tsx",
+  "exports": {
+    ".": {
+      "import": "./index.tsx",
+      "default": "./index.tsx"
+    }
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath, URL } from 'node:url';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
@@ -5,6 +6,13 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   base: '/Project-Alive/',
   plugins: [react()],
+  resolve: {
+    alias: {
+      'react-router-dom': fileURLToPath(
+        new URL('./vendor/react-router-dom/index.tsx', import.meta.url)
+      ),
+    },
+  },
   optimizeDeps: {
     exclude: ['lucide-react'],
   },


### PR DESCRIPTION
## Summary
- add a local `react-router-dom` shim and wire the build config to consume it
- refactor the application shell to render views through `<Routes>`/`<Route>` and wrap the entrypoint with `BrowserRouter`
- introduce a hero-style home view and expose it from the navigation via accessible `NavLink`s

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbf0b1f7d8833184df4d3fc4a9b44f