### PR TITLE
Make Vite base dynamic for GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      GITHUB_PAGES: 'true'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,9 +2,11 @@ import { fileURLToPath, URL } from 'node:url';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
+const base = process.env.GITHUB_PAGES === 'true' ? '/Project-Alive/' : '/';
+
 // https://vitejs.dev/config/
 export default defineConfig({
-  base: '/Project-Alive/',
+  base,
   plugins: [react()],
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- make the Vite configuration use a dynamic base path that reacts to the GITHUB_PAGES environment variable
- export GITHUB_PAGES=true in the GitHub Pages workflow so builds keep targeting the /Project-Alive/ prefix when deployed

## Testing
- npm run build *(fails: vite command not found because dependencies cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc0eed22c88331a866ce51c7bc73ab