### PR TITLE
refactor: import lucide icon type

### DIFF
--- a/src/components/KpiCard.tsx
+++ b/src/components/KpiCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { DivideIcon as LucideIcon } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
 
 interface KpiCardProps {
   title: string;


### PR DESCRIPTION
## Summary
- update the KPI card component to import `LucideIcon` as a type-only symbol while keeping the `icon` prop typed accordingly

## Testing
- npm run build *(fails: `vite` not found because dependencies cannot be installed in this environment; repeated 403 responses when attempting to download packages from the npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68cc19d601e88331a31083ad82b22a82