### PR TITLE
Fix Vite base path for GitHub Pages

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,9 +2,11 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
+  // Ensure the production build served via GitHub Pages resolves assets correctly
+  base: mode === 'production' ? '/Project-Alive/' : '/',
   plugins: [react()],
   optimizeDeps: {
     exclude: ['lucide-react'],
   },
-});
+}));


### PR DESCRIPTION
## Summary
- configure Vite to use the repository path as the base URL for production builds
- ensure assets resolve correctly when the site is served from GitHub Pages

## Testing
- npm_config_progress=false npm install *(fails: registry responded with 403 when fetching @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68cc1cc321cc8331b37a959bd2324703