### PR TITLE
Fix navigation type import causing runtime error

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ViewType } from '../App';
+import type { ViewType } from '../App';
 import { 
   LayoutDashboard, 
   Upload, 


### PR DESCRIPTION
## Summary
- ensure the navigation component only imports the `ViewType` union as a type to avoid bundling it as a runtime dependency
- unblock the application render path in production builds so the GitHub Pages deployment no longer throws missing export errors

## Testing
- Not run (npm install failed: registry access returns 403 errors in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68cc1e1a036c8331bbd3c9d72ff752d1