### PR TITLE
Fix GitHub Pages asset base paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="./vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Pégase - Financial Due Diligence Platform</title>
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="./src/main.tsx"></script>
   </body>
 </html>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,11 +2,16 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
-export default defineConfig(({ mode }) => ({
-  // Ensure the production build served via GitHub Pages resolves assets correctly
-  base: mode === 'production' ? '/Project-Alive/' : '/',
-  plugins: [react()],
-  optimizeDeps: {
-    exclude: ['lucide-react'],
-  },
-}));
+export default defineConfig(({ mode }) => {
+  const isProduction = mode === 'production';
+
+  return {
+    // Use a relative base path for the static build so GitHub Pages can serve
+    // the bundle correctly regardless of the repository name or nesting.
+    base: isProduction ? './' : '/',
+    plugins: [react()],
+    optimizeDeps: {
+      exclude: ['lucide-react'],
+    },
+  };
+});


### PR DESCRIPTION
## Summary
- update the Vite configuration to emit a relative base so GitHub Pages loads static assets correctly
- adjust index.html asset references to use relative paths compatible with the generated site

## Testing
- npm run build *(fails: vite is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc24ef32cc83319fe426a0b3a7d05b