### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,51 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build project
+        run: npm run build
+
+      - name: Upload build output
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Project Alive
+
+Ce dépôt contient une application Vite/React. Le déploiement vers GitHub Pages est automatisé via un workflow GitHub Actions situé dans [`.github/workflows/deploy.yml`](.github/workflows/deploy.yml).
+
+## Déploiement automatique
+
+Le workflow se déclenche lors d'un `push` sur la branche `main` ainsi que manuellement via `workflow_dispatch`. Il installe Node.js 18, exécute `npm ci`, construit l'application avec `npm run build`, puis publie le contenu du dossier `dist/` sur GitHub Pages.
+
+Après la première exécution du workflow, ouvrez **Settings → Pages** dans GitHub et sélectionnez **GitHub Actions** comme source de publication (ou la branche `gh-pages` si vous changez la stratégie de déploiement). Cette configuration permet de servir l'artefact généré par le workflow.
+
+## Vérifications locales
+
+Avant de pousser des modifications, vous pouvez vérifier que la génération aboutit correctement :
+
+```bash
+npm ci
+npm run build
+```
+
+Il est également recommandé d'exécuter le linting localement pour détecter les éventuels problèmes de style ou d'analyse statique :
+
+```bash
+npm run lint
+```
+
+Ces commandes vous permettent de valider la qualité du code avant de déclencher le déploiement automatique.


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds the site with Node 18 and publishes the dist/ artifact to GitHub Pages
- document how to verify the build (and optional lint) locally and note the GitHub Pages configuration step

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d27e9dc75c8331b2739ed859dff51e